### PR TITLE
refactor: SecurityConfig에서 accessDeniedHandler를 new 대신 선언 방법으로 변경#15

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/common/security/SecurityConfig.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/security/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.appcenter.timepiece.common.security;
 
-import com.appcenter.timepiece.common.exception.MemberAccessDeniedHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,6 +11,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 
@@ -25,7 +25,7 @@ public class SecurityConfig {
 
     private final AuthenticationEntryPoint entryPoint;
 
-
+    private final AccessDeniedHandler accessDeniedHandler;
 
     @Bean
     protected SecurityFilterChain configure(HttpSecurity httpSecurity) throws Exception{
@@ -48,7 +48,7 @@ public class SecurityConfig {
 
                 .exceptionHandling(httpSecurityExceptionHandlingConfigurer -> httpSecurityExceptionHandlingConfigurer
                 .authenticationEntryPoint(entryPoint)
-                .accessDeniedHandler(new MemberAccessDeniedHandler())
+                .accessDeniedHandler(accessDeniedHandler)
 
                 );
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #15 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 
![image](https://github.com/Your-Lie-in-April/server/assets/92552047/5c8f212b-5c48-4b05-a1a8-d6ee18d764b5)
SecurityConfig에서 accessDeniedHandler의 필터 등록 방식을 변경했습니다.

