### PR TITLE
swagger 접속 URl 허용 및 SpringBootTest 어노테이션 제거

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/common/security/SecurityConfig.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/security/SecurityConfig.java
@@ -52,7 +52,10 @@ public class SecurityConfig {
                         .accessDeniedHandler(accessDeniedHandler)
                 );
 
+
+
         return httpSecurity.build();
     }
+
 
 }

--- a/timepiece/src/test/java/com/appcenter/timepiece/TimepieceApplicationTests.java
+++ b/timepiece/src/test/java/com/appcenter/timepiece/TimepieceApplicationTests.java
@@ -1,9 +1,8 @@
 package com.appcenter.timepiece;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+//@SpringBootTest
 class TimepieceApplicationTests {
 
 	@Test


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

Close #23 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. SecurityConfig의 requestMatcher, Swagger 접속 경로 허용
2. 테스트 작성 시까지 사용되지 않던 SpringBootTest 어노테이션 제거

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
