### PR TITLE
보관 프로젝트 목록 조회 기능을 구현했습니다.

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/config/SwaggerApiResponses.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/config/SwaggerApiResponses.java
@@ -9,7 +9,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target({ElementType.METHOD})
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Operation()
 @ApiResponses(value = {

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
@@ -12,8 +12,10 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+
 @RequestMapping("")
 @RestController
+@SwaggerApiResponses
 @RequiredArgsConstructor
 public class ProjectController {
 
@@ -25,50 +27,51 @@ public class ProjectController {
      */
     @GetMapping("/v1/projects/all")
     @Operation(summary = "프로젝트 전체 조회", description = "")
-    @SwaggerApiResponses
     public ResponseEntity<CommonResponse<?>> findAllForTest() {
-        return ResponseEntity.ok().body(CommonResponse.success("", projectService.findAll()));
+        return ResponseEntity.ok().body(CommonResponse.success("전체 사용자 조회 성공", projectService.findAll()));
     }
 
     @GetMapping("/v1/projects/members/{memberId}")
     @Operation(summary = "소속 프로젝트 전체 조회(썸네일)", description = "")
-    @SwaggerApiResponses
     public ResponseEntity<CommonResponse<?>> findProjects(@PathVariable Long memberId) {
-        return ResponseEntity.ok().body(CommonResponse.success("",
+        return ResponseEntity.ok().body(CommonResponse.success("프로젝트 목록 조회 성공",
                 projectService.findProjects(memberId)));
     }
 
     // todo: Schedule 조회 로직의 작성이 선행되야 합니다.
     @GetMapping("/v1/projects/members/{memberId}/pin")
     @Operation(summary = "핀 설정된 프로젝트 조회(+시간표)", description = "")
-    @SwaggerApiResponses
     public ResponseEntity<CommonResponse<?>> findPinProjects(@PathVariable Long memberId) {
-        return ResponseEntity.ok().body(CommonResponse.success("",
+        return ResponseEntity.ok().body(CommonResponse.success("핀 설정된 프로젝트 조회 성공",
                 projectService.findPinProjects(memberId)));
     }
 
     @GetMapping("/v1/projects/members/{memberId}/{keyword}")
     @Operation(summary = "유저가 가지고 있는 프로젝트 중 검색", description = "")
-    @SwaggerApiResponses
     public ResponseEntity<CommonResponse<?>> searchProjects(@PathVariable Long memberId,
                                                             @PathVariable String keyword) {
-        return ResponseEntity.ok().body(CommonResponse.success("",
+        return ResponseEntity.ok().body(CommonResponse.success("프로젝트 검색 성공",
                 projectService.searchProjects(memberId, keyword)));
     }
 
     // todo: 해당 기능은 Project가 아닌 Member의 책임이 아닐까?
     @GetMapping("/v1/projects/{projectId}/members")
     @Operation(summary = "프로젝트에 속해있는 유저 전체 조회", description = "")
-    @SwaggerApiResponses
     public ResponseEntity<CommonResponse<?>> findMembersInProject(@PathVariable Long projectId) {
-        return ResponseEntity.ok().body(CommonResponse.success("",
+        return ResponseEntity.ok().body(CommonResponse.success("프로젝트 내 사용자 조회 성공",
                 projectService.findMembers(projectId)));
+    }
+
+    @GetMapping("/v1/projects/stored")
+    @Operation(summary = "보관 프로젝트 목록 조회", description = "")
+    public ResponseEntity<CommonResponse<?>> findStoredProjects(@AuthenticationPrincipal UserDetails userDetails) {
+        return ResponseEntity.ok().body(CommonResponse.success("보관 프로젝트 목록 조회 성공",
+                projectService.findStoredProjects(userDetails)));
     }
 
     @PostMapping("/v1/projects")
     @Operation(summary = "프로젝트 생성", description = "")
-    @SwaggerApiResponses
-    public ResponseEntity<CommonResponse> createProject(@RequestBody ProjectCreateUpdateRequest request,
+    public ResponseEntity<CommonResponse<?>> createProject(@RequestBody ProjectCreateUpdateRequest request,
                                                         @AuthenticationPrincipal UserDetails userDetails) {
         projectService.createProject(request, userDetails);
         return ResponseEntity.ok().body(CommonResponse.success("프로젝트 생성 성공", null));
@@ -76,7 +79,6 @@ public class ProjectController {
 
     @DeleteMapping("/v1/projects/{projectId}")
     @Operation(summary = "프로젝트 삭제", description = "")
-    @SwaggerApiResponses
     public ResponseEntity<CommonResponse<?>> kickProject(@PathVariable Long projectId,
                                                          @AuthenticationPrincipal UserDetails userDetails) {
         projectService.deleteProject(projectId, userDetails);
@@ -85,7 +87,6 @@ public class ProjectController {
 
     @PutMapping("/v1/projects/{projectId}")
     @Operation(summary = "프로젝트 수정", description = "")
-    @SwaggerApiResponses
     public ResponseEntity<CommonResponse<?>> updateProject(@PathVariable Long projectId,
                                                            @RequestBody ProjectCreateUpdateRequest request,
                                                            @AuthenticationPrincipal UserDetails userDetails) {
@@ -95,7 +96,6 @@ public class ProjectController {
 
     @PostMapping("/v1/projects/{projectId}/invitation")
     @Operation(summary = "회원 초대 링크 생성", description = "")
-    @SwaggerApiResponses
     public CommonResponse<?> generateInviteLink(@PathVariable Long projectId,
                                                 @AuthenticationPrincipal UserDetails userDetails) {
         return CommonResponse.success("초대링크를 성공적으로 생성했습니다",
@@ -104,7 +104,6 @@ public class ProjectController {
 
     @DeleteMapping("/v1/projects/{projectId}/members/{memberId}")
     @Operation(summary = "회원 강퇴", description = "")
-    @SwaggerApiResponses
     public CommonResponse<Void> kick(@PathVariable Long projectId,
                                      @PathVariable Long memberId,
                                      @AuthenticationPrincipal UserDetails userDetails) {
@@ -114,7 +113,6 @@ public class ProjectController {
 
     @DeleteMapping("/v1/projects/{projectId}/me")
     @Operation(summary = "프로젝트 나가기", description = "")
-    @SwaggerApiResponses
     public CommonResponse<Void> goOut(@PathVariable Long projectId,
                                       @AuthenticationPrincipal UserDetails userDetails) {
         projectService.goOut(projectId, userDetails);
@@ -123,7 +121,6 @@ public class ProjectController {
 
     @PatchMapping("/v1/projects/{projectId}/transfer-privilege")
     @Operation(summary = "관리자 권한 양도", description = "")
-    @SwaggerApiResponses
     public CommonResponse<Void> transferPrivilege(@PathVariable Long projectId,
                                                   @RequestBody TransferPrivilegeRequest request,
                                                   @AuthenticationPrincipal UserDetails userDetails) {
@@ -133,7 +130,6 @@ public class ProjectController {
 
     @PostMapping("/v1/invitation/{url}")
     @Operation(summary = "회원 초대(추가)", description = "")
-    @SwaggerApiResponses
     public CommonResponse<Void> join(@PathVariable String url,
                                      @AuthenticationPrincipal UserDetails userDetails) {
         projectService.addUserToGroup(url, userDetails);

--- a/timepiece/src/main/java/com/appcenter/timepiece/repository/ProjectRepository.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/repository/ProjectRepository.java
@@ -18,4 +18,9 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
             "join mp.member m " +
             "where m.id = :memberId and p.title like %:keyword%")
     List<Project> findProjectByMemberIdAndTitleLikeKeyword(Long memberId, String keyword);
+
+    @Query("select distinct p from Project p " +
+            "join p.memberProjects mp " +
+            "where mp.member.id = :memberId and mp.isStored = TRUE ")
+    List<Project> findAllByMemberIdWhereIsStored(Long memberId);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #39 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 보관 프로젝트 목록의 조회 기능을 구현했습니다.
![image](https://github.com/Your-Lie-in-April/server/assets/121238128/f4660466-b3ad-4973-ab6b-afe49a8e6291)

- SwaggerApiResponses 어노테이션의 대상 타입에 클래스를 추가할 수 있도록 ElementType.TYPE을 추가하고 ProjectController 내 클래스에 달리도록 수정했습니다.

