### PR TITLE
프로젝트 멤버 조회 기능에서 멤버의 닉네임이 프로젝트 별 닉네임을 반환하도록 수정하였습니다.

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
@@ -57,9 +57,10 @@ public class ProjectController {
     // todo: 해당 기능은 Project가 아닌 Member의 책임이 아닐까?
     @GetMapping("/v1/projects/{projectId}/members")
     @Operation(summary = "프로젝트에 속해있는 유저 전체 조회", description = "")
-    public ResponseEntity<CommonResponse<?>> findMembersInProject(@PathVariable Long projectId) {
+    public ResponseEntity<CommonResponse<?>> findMembersInProject(@PathVariable Long projectId,
+                                                                  @AuthenticationPrincipal UserDetails userDetails) {
         return ResponseEntity.ok().body(CommonResponse.success("프로젝트 내 사용자 조회 성공",
-                projectService.findMembers(projectId)));
+                projectService.findMembers(projectId, userDetails)));
     }
 
     @GetMapping("/v1/projects/stored")

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/member/MemberResponse.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/member/MemberResponse.java
@@ -36,4 +36,14 @@ public class MemberResponse {
                 .profileImageUrl(member.getProfileImageUrl())
                 .build();
     }
+
+    public static MemberResponse of(Member member, String nickname) {
+        return MemberResponse.builder()
+                .memberId(member.getId())
+                .email(member.getEmail())
+                .nickname(nickname)
+                .state(member.getState())
+                .profileImageUrl(member.getProfileImageUrl())
+                .build();
+    }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/repository/MemberProjectRepository.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/repository/MemberProjectRepository.java
@@ -17,6 +17,11 @@ public interface MemberProjectRepository extends JpaRepository<MemberProject, Lo
             "where mp.member.id = :memberId")
     List<MemberProject> findMemberProjectsWithProjectAndCover(Long memberId);
 
+    @Query("select mp from MemberProject mp " +
+            "join mp.project p " +
+            "where p.id = :projectId")
+    List<MemberProject> findByProjectIdWithMember(Long projectId);
+
     List<MemberProject> findByMemberIdAndIsPinnedIsTrue(Long memberId);
 
     Optional<MemberProject> findByMemberIdAndProjectId(Long memberId, Long projectId);

--- a/timepiece/src/main/java/com/appcenter/timepiece/repository/MemberRepository.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/repository/MemberRepository.java
@@ -2,18 +2,10 @@ package com.appcenter.timepiece.repository;
 
 import com.appcenter.timepiece.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-
-    @Query("select m from MemberProject mp " +
-            "join mp.project p " +
-            "join mp.member m " +
-            "where p.id = :projectId")
-    List<Member> findByProjectIdWithMember(Long projectId);
 
     Optional<Member> findByEmail(String email);
 

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
@@ -12,10 +12,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import static java.util.Objects.requireNonNull;
 
 @Slf4j
 @Service
@@ -62,8 +60,13 @@ public class ProjectService {
                 .stream().map(p -> ProjectThumbnailResponse.of(p, ((p.getCover() == null) ? null : p.getCover().getCoverImageUrl()))).toList();
     }
 
+    @Transactional(readOnly=true)
     public List<MemberResponse> findMembers(Long projectId) {
-        return memberRepository.findByProjectIdWithMember(projectId).stream().map(MemberResponse::from).toList();
+        return memberProjectRepository.findByProjectIdWithMember(projectId).stream()
+                .map(memberProject -> {
+                    Member member = requireNonNull(memberProject.getMember());
+                    return MemberResponse.of(member, memberProject.getNickname());
+                }).toList();
     }
 
     public void createProject(ProjectCreateUpdateRequest request, UserDetails userDetails) {

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
-
 import static java.util.Objects.requireNonNull;
 
 @Slf4j


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #37 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 프로젝트 내 멤버 조회 시, 프로젝트 별 닉네임이 적용되도록 수정하였습니다.  
![image](https://github.com/Your-Lie-in-April/server/assets/121238128/d0aec172-7dfa-4833-8b2f-619a381f3805)

2. 프로젝트 내 멤버 조회 시, 자신이 속해있는 프로젝트만 조회가 가능하도록 수정했습니다.
  * 현재 로그인한 사용자의 토큰 정보를 통해, MemberProject 정보가 존재하는지 확인합니다. 발견하지 못 한 경우 요청은 실패합니다. 
<img width="1413" alt="스크린샷 2024-03-23 오후 3 24 57" src="https://github.com/Your-Lie-in-April/server/assets/121238128/4cb003df-a0a9-43d3-a03d-2fc503827e8f">

## 💬리뷰 요구사항(선택)

이제 프로젝트 멤버 조회 시 자신이 속해있는 프로젝트인지 먼저 확인합니다.
반면, 다른 조회 기능들에 대해서는 앞서 확인하는 기능이 없습니다.
모든 조회 기능에 대해 추가하는 것이 좋을까요??
