### PR TITLE
sevice계층에서 MemberId 얻어오는 로직 모두 userDetails로 수정 완료. 

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/MemberController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/MemberController.java
@@ -5,7 +5,6 @@ import com.appcenter.timepiece.config.SwaggerApiResponses;
 import com.appcenter.timepiece.service.MemberService;
 import com.appcenter.timepiece.service.ProjectService;
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -44,16 +43,16 @@ public class MemberController {
     @PutMapping(value = "/v1/projects/members/nickname")
     @Operation(summary = "닉네임 재설정", description = "")
     @SwaggerApiResponses
-    public ResponseEntity<CommonResponse> editUserNickname(Long projectId, String nickname, HttpServletRequest request) {
-        memberService.editMemberNickname(projectId, nickname, request);
+    public ResponseEntity<CommonResponse> editUserNickname(Long projectId, String nickname, @AuthenticationPrincipal UserDetails userDetails) {
+        memberService.editMemberNickname(projectId, nickname, userDetails);
         return ResponseEntity.status(HttpStatus.OK).body(new CommonResponse(1, "성공", null));
     }
 
     @PutMapping(value = "/v1/members/{state}")
     @Operation(summary = "상태메시지 설정", description = "")
     @SwaggerApiResponses
-    public ResponseEntity<CommonResponse> editUserState(@PathVariable String state, HttpServletRequest request) {
-        memberService.editMemberState(state, request);
+    public ResponseEntity<CommonResponse> editUserState(@PathVariable String state, @AuthenticationPrincipal UserDetails userDetails) {
+        memberService.editMemberState(state, userDetails);
         return ResponseEntity.status(HttpStatus.OK).body(new CommonResponse(1, "성공", null));
 
     }
@@ -61,8 +60,8 @@ public class MemberController {
     @PatchMapping("/v1/members/storage/{projectId}")
     @Operation(summary = "프로젝트 보관 설정/해제", description = "")
     @SwaggerApiResponses
-    public ResponseEntity<CommonResponse> storeProject(@PathVariable Long projectId, HttpServletRequest request) {
-        memberService.storeProject(projectId, request);
+    public ResponseEntity<CommonResponse> storeProject(@PathVariable Long projectId, @AuthenticationPrincipal UserDetails userDetails) {
+        memberService.storeProject(projectId, userDetails);
         return ResponseEntity.status(HttpStatus.OK).body(new CommonResponse(1, "성공", null));
     }
 

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/OAuth2Controller.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/OAuth2Controller.java
@@ -6,11 +6,12 @@ import com.appcenter.timepiece.config.SwaggerApiResponses;
 import com.appcenter.timepiece.service.OAuth2Service;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -35,9 +36,7 @@ public class OAuth2Controller {
 
     @Operation(hidden = true)
     @GetMapping(value = "/login/google")
-    public ResponseEntity<CommonResponse> sign(HttpServletRequest request,
-                                               @RequestParam(value = "code") String authCode,
-                                               HttpServletResponse response) throws Exception {
+    public ResponseEntity<CommonResponse> sign(@RequestParam(value = "code") String authCode) throws Exception {
 
         return ResponseEntity.status(HttpStatus.OK).body(new CommonResponse(1, "성공", oAuth2Service.getGoogleInfo(authCode)));
 
@@ -53,14 +52,14 @@ public class OAuth2Controller {
     @GetMapping(value = "/test")
     @Operation(summary = "테스트API", description = "")
     @SwaggerApiResponses
-    public ResponseEntity<CommonResponse> testApi(HttpServletRequest request) {
-        return ResponseEntity.status(HttpStatus.OK).body(new CommonResponse(1, "테스트 성공", oAuth2Service.testApi(request)));
+    public ResponseEntity<CommonResponse> testApi(@AuthenticationPrincipal UserDetails userDetails) {
+        return ResponseEntity.status(HttpStatus.OK).body(new CommonResponse(1, "테스트 성공", oAuth2Service.testApi(userDetails)));
     }
 
     @GetMapping(value = "/test1")
     @Operation(summary = "테스트API", description = "")
     @SwaggerApiResponses
-    public ResponseEntity<CommonResponse> testApi1(HttpServletRequest request) {
-        return ResponseEntity.status(HttpStatus.OK).body(new CommonResponse(1, "테스트 성공", oAuth2Service.testApi(request)));
+    public ResponseEntity<CommonResponse> testApi1(@AuthenticationPrincipal UserDetails userDetails) {
+        return ResponseEntity.status(HttpStatus.OK).body(new CommonResponse(1, "테스트 성공", oAuth2Service.testApi(userDetails)));
     }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/MemberService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/MemberService.java
@@ -2,15 +2,16 @@ package com.appcenter.timepiece.service;
 
 import com.appcenter.timepiece.common.exception.ExceptionMessage;
 import com.appcenter.timepiece.common.exception.NotFoundElementException;
+import com.appcenter.timepiece.common.security.CustomUserDetails;
 import com.appcenter.timepiece.common.security.JwtProvider;
 import com.appcenter.timepiece.domain.Member;
 import com.appcenter.timepiece.domain.MemberProject;
 import com.appcenter.timepiece.dto.member.MemberResponse;
 import com.appcenter.timepiece.repository.MemberProjectRepository;
 import com.appcenter.timepiece.repository.MemberRepository;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -45,9 +46,9 @@ public class MemberService {
         return MemberResponse.from(member);
     }
 
-    public void storeProject(Long projectId, HttpServletRequest request) {
+    public void storeProject(Long projectId, UserDetails userDetails) {
         log.info("[storeProject] 프로젝트 보관");
-        Long memberId = jwtProvider.getMemberId(jwtProvider.resolveServiceToken(request));
+        Long memberId = ((CustomUserDetails) userDetails).getId();
 
         MemberProject memberProject = memberProjectRepository.findByMemberIdAndProjectId(memberId, projectId)
                 .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.MEMBER_PROJECT_NOT_FOUND));
@@ -57,10 +58,10 @@ public class MemberService {
         memberProjectRepository.save(memberProject);
     }
 
-    public void editMemberState(String state, HttpServletRequest request) {
+    public void editMemberState(String state, UserDetails userDetails) {
         log.info("[editMemberState] 멤버 상태 수정 state = {}", state);
 
-        Long memberId = jwtProvider.getMemberId(jwtProvider.resolveServiceToken(request));
+        Long memberId = ((CustomUserDetails) userDetails).getId();
         log.info("memberId = {}", memberId);
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.MEMBER_NOTFOUND));
@@ -69,8 +70,8 @@ public class MemberService {
         memberRepository.save(member);
     }
 
-    public void editMemberNickname(Long projectId, String nickName, HttpServletRequest request) {
-        Long memberId = jwtProvider.getMemberId(jwtProvider.resolveServiceToken(request));
+    public void editMemberNickname(Long projectId, String nickName, UserDetails userDetails) {
+        Long memberId = ((CustomUserDetails) userDetails).getId();
 
         MemberProject memberProject = memberProjectRepository.findByMemberIdAndProjectId(memberId, projectId)
                 .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.MEMBER_PROJECT_NOT_FOUND));

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/OAuth2Service.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/OAuth2Service.java
@@ -5,6 +5,7 @@ import com.appcenter.timepiece.common.exception.FailedCreateTokenException;
 import com.appcenter.timepiece.common.exception.NotFoundElementException;
 import com.appcenter.timepiece.common.redis.RefreshToken;
 import com.appcenter.timepiece.common.redis.RefreshTokenRepository;
+import com.appcenter.timepiece.common.security.CustomUserDetails;
 import com.appcenter.timepiece.common.security.JwtProvider;
 import com.appcenter.timepiece.common.security.Role;
 import com.appcenter.timepiece.domain.Member;
@@ -19,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -179,12 +181,10 @@ public class OAuth2Service {
         }
     }
 
-    public String testApi(HttpServletRequest request) {
+    public String testApi(UserDetails userDetails) {
         log.info("[testApi] memberId 추출중");
 
-        String token = jwtProvider.resolveServiceToken(request);
-
-        Long memberId = jwtProvider.getMemberId(token);
+        Long memberId = ((CustomUserDetails) userDetails).getId();
         log.info("[testApi] memberId 추출 성공. memberId = {}", memberId);
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.MEMBER_NOTFOUND));


### PR DESCRIPTION
## #️⃣연관된 이슈

close #38 

## 📝작업 내용

request를 사용해서 memberId를 얻어오는 로직에서 userDetails로 얻어오는 방식으로 변경(reissueToken은 로직 상 request가 필요하기 때문에 남겨놓음.)
