### PR TITLE
초대 링크 생성 및 링크를 통한 가입에 인코딩/디코딩 로직을 추가하였습니다.

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/common/exception/ExceptionMessage.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/exception/ExceptionMessage.java
@@ -7,11 +7,17 @@ public enum ExceptionMessage {
     TOKEN_NOT_AUTHORIZED("권한이 없습니다", 0, HttpStatus.FORBIDDEN),
     TOKEN_UNAUTHENTICATED("인증되지 않은 토큰입니다.", 0, HttpStatus.UNAUTHORIZED),
     TOKEN_INVALID_FORMAT("잘못된 형식의 토큰입니다.", 0, HttpStatus.UNAUTHORIZED),
-    MEMBER_NOTFOUND("멤버가 존재하지 않습니다.", 0, HttpStatus.NOT_FOUND),
+    MEMBER_NOT_FOUND("멤버가 존재하지 않습니다.", 0, HttpStatus.NOT_FOUND),
     TOKEN_NOT_FOUND("토큰이 비었거나 null입니다", 0, HttpStatus.BAD_REQUEST),
     TOKEN_TYPE_INVALID("토큰 타입이 틀렸습니다.", 0, HttpStatus.BAD_REQUEST),
-    MEMBER_PROJECT_NOT_FOUND("멤버-프로젝트가 존재하지 않습니다.", 0, HttpStatus.NOT_FOUND);
-
+    MEMBER_PROJECT_NOT_FOUND("멤버-프로젝트가 존재하지 않습니다.", 0, HttpStatus.NOT_FOUND),
+    PROJECT_NOT_FOUND("프로젝트가 존재하지 않습니다.", 0, HttpStatus.NOT_FOUND),
+    KICK_ADMIN("프로젝트 관리자는 강퇴할 수 없습니다", 0, HttpStatus.BAD_REQUEST),
+    LINK_EXPIRED("초대링크의 유효날짜가 지났습니다.", 0, HttpStatus.BAD_REQUEST),
+    DUPLICATE_SIGN_REQUEST("중복된 가입요청입니다.", 0, HttpStatus.BAD_REQUEST),
+    INSUFFICIENT_PRIVILEGE("프로젝트 관리자 권한이 없습니다.", 0, HttpStatus.BAD_REQUEST),
+    ADMIN_LEAVE("관리자는 나갈 수 없습니다", 0, HttpStatus.BAD_REQUEST),
+    NOT_MEMBER("속하지 않은 프로젝트 정보를 조회할 수 없습니다.", 0, HttpStatus.BAD_REQUEST);
 
     private final String message;
 

--- a/timepiece/src/main/java/com/appcenter/timepiece/common/exception/FailedCreateTokenException.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/exception/FailedCreateTokenException.java
@@ -1,8 +1,0 @@
-package com.appcenter.timepiece.common.exception;
-
-public class FailedCreateTokenException extends RuntimeException {
-
-    public FailedCreateTokenException(String m) {
-        super(m);
-    }
-}

--- a/timepiece/src/main/java/com/appcenter/timepiece/common/exception/FailedTokenCreateException.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/exception/FailedTokenCreateException.java
@@ -1,0 +1,8 @@
+package com.appcenter.timepiece.common.exception;
+
+public class FailedTokenCreateException extends RuntimeException {
+
+    public FailedTokenCreateException(ExceptionMessage message) {
+        super(message.getMessage());
+    }
+}

--- a/timepiece/src/main/java/com/appcenter/timepiece/common/exception/GlobalExceptionHandler.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/exception/GlobalExceptionHandler.java
@@ -44,4 +44,13 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(CommonResponse.error(e.getMessage(), null));
     }
 
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<CommonResponse<?>> handleIllegalStateException(IllegalStateException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(CommonResponse.error(e.getMessage(), null));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<CommonResponse<?>> handleIllegalArgumentException(IllegalArgumentException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(CommonResponse.error(e.getMessage(), null));
+    }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/common/exception/GlobalExceptionHandler.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/exception/GlobalExceptionHandler.java
@@ -21,8 +21,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     }
 
-    @ExceptionHandler(value = FailedCreateTokenException.class)
-    public ResponseEntity<CommonResponse> handleTokenCreateError(FailedCreateTokenException ex) {
+    @ExceptionHandler(value = FailedTokenCreateException.class)
+    public ResponseEntity<CommonResponse> handleTokenCreateError(FailedTokenCreateException ex) {
         log.error(ex.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new CommonResponse(0, ex.getMessage(), null));
     }

--- a/timepiece/src/main/java/com/appcenter/timepiece/common/exception/NotEnoughPrivilegeException.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/exception/NotEnoughPrivilegeException.java
@@ -1,7 +1,7 @@
 package com.appcenter.timepiece.common.exception;
 
 public class NotEnoughPrivilegeException extends RuntimeException {
-    public NotEnoughPrivilegeException(String m) {
-        super(m);
+    public NotEnoughPrivilegeException(ExceptionMessage message) {
+        super(message.getMessage());
     }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/MemberService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/MemberService.java
@@ -31,17 +31,15 @@ public class MemberService {
         log.info("[getAllMember] 모든 유저 조회");
         List<Member> members = memberRepository.findAll();
 
-        List<MemberResponse> memberResponses = members.stream()
+        return members.stream()
                 .map(MemberResponse::from).toList();
-
-        return memberResponses;
     }
 
     public MemberResponse getMemberInfo(Long memberId) {
         log.info("[getMemberInfo] 유저의 정보 조회");
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.MEMBER_NOTFOUND));
+                .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.MEMBER_NOT_FOUND));
 
         return MemberResponse.from(member);
     }
@@ -64,7 +62,7 @@ public class MemberService {
         Long memberId = ((CustomUserDetails) userDetails).getId();
         log.info("memberId = {}", memberId);
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.MEMBER_NOTFOUND));
+                .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.MEMBER_NOT_FOUND));
 
         member.editState(state);
         memberRepository.save(member);

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/OAuth2Service.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/OAuth2Service.java
@@ -1,7 +1,7 @@
 package com.appcenter.timepiece.service;
 
 import com.appcenter.timepiece.common.exception.ExceptionMessage;
-import com.appcenter.timepiece.common.exception.FailedCreateTokenException;
+import com.appcenter.timepiece.common.exception.FailedTokenCreateException;
 import com.appcenter.timepiece.common.exception.NotFoundElementException;
 import com.appcenter.timepiece.common.redis.RefreshToken;
 import com.appcenter.timepiece.common.redis.RefreshTokenRepository;
@@ -154,7 +154,7 @@ public class OAuth2Service {
         log.info("[reissueAccessToken] memberId 추출 성공. memberId = {}", memberId);
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.MEMBER_NOTFOUND));
+                .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.MEMBER_NOT_FOUND));
         log.info("[reissueAccessToken] member 찾기 성공. memberEmail = {}", member.getEmail());
 
         RefreshToken refreshToken = refreshTokenRepository.findByMemberId(memberId);
@@ -177,7 +177,7 @@ public class OAuth2Service {
 
             return tokens;
         } else {
-            throw new FailedCreateTokenException("accessToken 제작 실패");
+            throw new FailedTokenCreateException(ExceptionMessage.TOKEN_EXPIRED);
         }
     }
 
@@ -187,7 +187,7 @@ public class OAuth2Service {
         Long memberId = ((CustomUserDetails) userDetails).getId();
         log.info("[testApi] memberId 추출 성공. memberId = {}", memberId);
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.MEMBER_NOTFOUND));
+                .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.MEMBER_NOT_FOUND));
         log.info("[testApi] member 찾기 성공. memberEmail = {}", member.getEmail());
 
         return member.toString();

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
@@ -6,14 +6,17 @@ import com.appcenter.timepiece.domain.*;
 import com.appcenter.timepiece.dto.member.MemberResponse;
 import com.appcenter.timepiece.dto.project.*;
 import com.appcenter.timepiece.repository.*;
+import com.appcenter.timepiece.util.AESEncoder;
+import com.appcenter.timepiece.util.LinkValidTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
-import static java.util.Objects.requireNonNull;
 
 @Slf4j
 @Service
@@ -25,6 +28,7 @@ public class ProjectService {
     private final MemberProjectRepository memberProjectRepository;
     private final CoverRepository coverRepository;
     private final InvitationRepository invitationRepository;
+    private final AESEncoder aesEncoder;
 
     public List<ProjectResponse> findAll() {
         return projectRepository.findAllWithCover().stream().map(p ->
@@ -65,7 +69,7 @@ public class ProjectService {
         validateMemberIsInProject(projectId, userDetails);
         return memberProjectRepository.findByProjectIdWithMember(projectId).stream()
                 .map(memberProject -> {
-                    Member member = requireNonNull(memberProject.getMember());
+                    Member member = Objects.requireNonNull(memberProject.getMember());
                     return MemberResponse.of(member, memberProject.getNickname());
                 }).toList();
     }
@@ -123,32 +127,42 @@ public class ProjectService {
         memberProjectRepository.delete(memberProject);
     }
 
-    public Map<String, String> generateInviteLink(Long projectId, UserDetails userDetails) {
+    public String generateInviteLink(Long projectId, UserDetails userDetails) {
         validateRequesterIsPrivileged(projectId, userDetails);
 
+        Member member = memberRepository.findById(((CustomUserDetails)userDetails).getId())
+                .orElseThrow(() -> new IllegalStateException("요청자의 정보를 찾을 수 없습니다."));
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 프로젝트입니다"));
 
-        // todo: project 별 고유 정보를 통해 링크생성(인코딩)
-        String url = String.valueOf(projectId);
+        String urlData = new StringBuilder().append(projectId)
+                .append("?").append(member.getNickname())
+                .append("?").append(LocalDateTime.now().plusDays(LinkValidTime.WEEK.value()))
+                .toString();
 
-        Map<String, String> urlData = new HashMap<>();
-        urlData.put("url", url);
-
+        String url = aesEncoder.encryptAES256(urlData);
         invitationRepository.save(Invitation.of(project, url));
-        return urlData;
+        return url;
     }
 
     public void addUserToGroup(String url, UserDetails userDetails) {
-        // todo: url 정보를 통해 초대받은 프로젝트 정보를 파싱해서 꺼내옴 + Inivation 엔티티 존재 확인
-        Long projectId = Long.valueOf(url);
+        // todo:  Inivation 엔티티 존재 확인 + 어떻게 삭제할 것인지?
+        StringTokenizer st = new StringTokenizer(aesEncoder.decryptAES256(url), "?");
+        Long projectId = Long.valueOf(st.nextToken());
+
+        String invitator = st.nextToken();
+
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS");
+        LocalDateTime linkTime = LocalDateTime.parse(st.nextToken(), dateTimeFormatter);
+        if (linkTime.isBefore(LocalDateTime.now())) {
+            throw new IllegalStateException("초대링크의 유효날짜가 지났습니다.");
+        }
+
+        Long memberId = ((CustomUserDetails) userDetails).getId();
+        validateJoinIsNotDuplicate(memberId, projectId);
 
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 프로젝트입니다"));
-        Long memberId = ((CustomUserDetails) userDetails).getId();
-
-        validateJoinIsNotDuplicate(project, memberId);
-
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 멤버입니다"));
 
@@ -156,8 +170,8 @@ public class ProjectService {
         memberProjectRepository.save(memberProject);
     }
 
-    private void validateJoinIsNotDuplicate(Project project, Long memberId) {
-        boolean isExist = memberProjectRepository.existsByMemberIdAndProjectId(memberId, project.getId());
+    private void validateJoinIsNotDuplicate(Long memberId, Long projectId) {
+        boolean isExist = memberProjectRepository.existsByMemberIdAndProjectId(memberId, projectId);
         if (isExist) {
             // todo: Exception 변경 및 예외처리 핸들러
             throw new IllegalStateException("이미 가입된 사용자입니다");

--- a/timepiece/src/main/java/com/appcenter/timepiece/util/AESEncoder.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/util/AESEncoder.java
@@ -1,0 +1,68 @@
+package com.appcenter.timepiece.util;
+
+import org.apache.tomcat.util.codec.binary.Base64;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.codec.EncodingException;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class AESEncoder {
+    @Value("${util.encoder.invitation-link-encoder.alg}")
+    private String alg;
+
+    @Value("${util.encoder.invitation-link-encoder.key}")
+    private String key;
+
+    @Value("${util.encoder.invitation-link-encoder.iv}")
+    private String iv;
+
+    public String encryptAES256(String text) {
+        Cipher cipher;
+        byte[] encrypted;
+
+        try {
+            cipher = Cipher.getInstance(alg);
+            SecretKeySpec keySpec = new SecretKeySpec(key.getBytes(), "AES");
+            IvParameterSpec ivParamSpec = new IvParameterSpec(iv.getBytes());
+            cipher.init(Cipher.ENCRYPT_MODE, keySpec, ivParamSpec);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to init: encoder");
+        }
+
+        try {
+            encrypted = cipher.doFinal(text.getBytes(StandardCharsets.UTF_8));
+        } catch (IllegalBlockSizeException | BadPaddingException e) {
+            throw new EncodingException("Failed to encoding: generate Invitation Link");
+        }
+        return Base64.encodeBase64URLSafeString(encrypted);
+    }
+
+    public String decryptAES256(String cipherText) {
+        Cipher cipher;
+        byte[] decrypted;
+
+        try {
+            cipher = Cipher.getInstance(alg);
+            SecretKeySpec keySpec = new SecretKeySpec(key.getBytes(), "AES");
+            IvParameterSpec ivParamSpec = new IvParameterSpec(iv.getBytes());
+            cipher.init(Cipher.DECRYPT_MODE, keySpec, ivParamSpec);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to init: decoder");
+        }
+
+        try {
+            byte[] decodedBytes = Base64.decodeBase64URLSafe(cipherText);
+            decrypted = cipher.doFinal(decodedBytes);
+        } catch (IllegalBlockSizeException | BadPaddingException e) {
+            throw new IllegalArgumentException("Failed to decoding: invalid Invitation Link");
+        }
+        return new String(decrypted, StandardCharsets.UTF_8);
+    }
+}

--- a/timepiece/src/main/java/com/appcenter/timepiece/util/LinkValidTime.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/util/LinkValidTime.java
@@ -1,0 +1,18 @@
+package com.appcenter.timepiece.util;
+
+
+public enum LinkValidTime {
+    DAY(1),
+    WEEK(7),
+    MONTH(31);
+
+    private final int value;
+
+    public int value() {
+        return value;
+    }
+
+    LinkValidTime(int value) {
+        this.value = value;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #42 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

* 암/복호화: AES 256 사용
* 전역 예외처리: IllegalArgumentException, IllegalStateException 추가
* 링크 내 (링크)만료 정보 추가 -> LinkValidTime Enum 클래스 추가

### 스크린샷 (선택)
1. 정상
![image](https://github.com/Your-Lie-in-April/server/assets/121238128/13fa0749-567a-4de4-b90a-6203a06c58a4)

2. 중복가입
![image](https://github.com/Your-Lie-in-April/server/assets/121238128/cc51c5dc-13b9-4ca5-8b59-f345a14613bc)


3. 유효하지 않은 URL
세 가지 예외가 발생합니다.
  1) Failed to decoding -> 의도된 예외
  2) IllegalArgumentException("Last encoded character (before the paddings if any) is a valid base 64 alphabet but not a possible value. Expected the discarded bits to be zero.")
  3)  IllegalStateException("Impossible modulus [1]")

2, 3번은 어떻게 잡아야할지 잘 모르겠네요.

<img width="1440" alt="스크린샷 2024-03-23 오후 8 18 07" src="https://github.com/Your-Lie-in-April/server/assets/121238128/056537db-7606-4e51-b0db-68fade0b4f29">


## 💬리뷰 요구사항(선택)
1. 예외
눈에 보인는 예외는 다 처리했는데 어디서 나오는 지 모르겠네요. (+갑자기 스크린샷도 안 찍혀서 첨부하지도 못 하네요)
관련 링크 첨부합니다.
https://okky.kr/questions/1493755#answer-769133
[Hadling Java Crypto Exception](https://stackoverflow.com/questions/15709421/handling-java-crypto-exceptions)

2. Invitation 저장/삭제와 관련하여
초대링크 발급 시 링크 URL이 DB에 저장됩니다. 
링크를 만들 때 초대자, 만료일에 대한 정보를 포함하였기 때문에 프로젝트 가입 로직에서는 Invitation 테이블 조회를 수행하지 않습니다.
