### PR TITLE
feat: 접근 권한 확인 로직 작성#45

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/common/exception/ExceptionMessage.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/exception/ExceptionMessage.java
@@ -17,7 +17,9 @@ public enum ExceptionMessage {
     DUPLICATE_SIGN_REQUEST("중복된 가입요청입니다.", 0, HttpStatus.BAD_REQUEST),
     INSUFFICIENT_PRIVILEGE("프로젝트 관리자 권한이 없습니다.", 0, HttpStatus.BAD_REQUEST),
     ADMIN_LEAVE("관리자는 나갈 수 없습니다", 0, HttpStatus.BAD_REQUEST),
-    NOT_MEMBER("속하지 않은 프로젝트 정보를 조회할 수 없습니다.", 0, HttpStatus.BAD_REQUEST);
+    NOT_MEMBER("속하지 않은 프로젝트 정보를 조회할 수 없습니다.", 0, HttpStatus.BAD_REQUEST),
+    MEMBER_UNAUTHENTICATED("접근 권한이 없는 페이지입니다.", 0, HttpStatus.UNAUTHORIZED);
+
 
     private final String message;
 

--- a/timepiece/src/main/java/com/appcenter/timepiece/common/security/JwtProvider.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/security/JwtProvider.java
@@ -3,26 +3,26 @@ package com.appcenter.timepiece.common.security;
 import com.appcenter.timepiece.common.exception.ExceptionMessage;
 import com.appcenter.timepiece.common.exception.JwtEmptyException;
 import com.appcenter.timepiece.common.exception.MismatchTokenTypeException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import jakarta.servlet.http.HttpServletRequest;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-
-
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 @Service
 @Slf4j
@@ -70,6 +70,12 @@ public class JwtProvider {
         claims.put("type", "access");
 
         Date now = new Date();
+        
+        SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd");
+        System.out.println(format.format(now)); // 20090529
+        format = new SimpleDateFormat("E MMM dd HH:mm:ss", Locale.KOREA);
+        System.out.println(format.format(now));
+
         String token = Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(now)

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
@@ -33,25 +33,25 @@ public class ProjectController {
 
     @GetMapping("/v1/projects/members/{memberId}")
     @Operation(summary = "소속 프로젝트 전체 조회(썸네일)", description = "")
-    public ResponseEntity<CommonResponse<?>> findProjects(@PathVariable Long memberId) {
+    public ResponseEntity<CommonResponse<?>> findProjects(@PathVariable Long memberId, @AuthenticationPrincipal UserDetails userDetails) {
         return ResponseEntity.ok().body(CommonResponse.success("프로젝트 목록 조회 성공",
-                projectService.findProjects(memberId)));
+                projectService.findProjects(memberId, userDetails)));
     }
 
     // todo: Schedule 조회 로직의 작성이 선행되야 합니다.
     @GetMapping("/v1/projects/members/{memberId}/pin")
     @Operation(summary = "핀 설정된 프로젝트 조회(+시간표)", description = "")
-    public ResponseEntity<CommonResponse<?>> findPinProjects(@PathVariable Long memberId) {
+    public ResponseEntity<CommonResponse<?>> findPinProjects(@PathVariable Long memberId, @AuthenticationPrincipal UserDetails userDetails) {
         return ResponseEntity.ok().body(CommonResponse.success("핀 설정된 프로젝트 조회 성공",
-                projectService.findPinProjects(memberId)));
+                projectService.findPinProjects(memberId, userDetails)));
     }
 
     @GetMapping("/v1/projects/members/{memberId}/{keyword}")
     @Operation(summary = "유저가 가지고 있는 프로젝트 중 검색", description = "")
-    public ResponseEntity<CommonResponse<?>> searchProjects(@PathVariable Long memberId,
+    public ResponseEntity<CommonResponse<?>> searchProjects(@PathVariable Long memberId, @AuthenticationPrincipal UserDetails userDetails,
                                                             @PathVariable String keyword) {
         return ResponseEntity.ok().body(CommonResponse.success("프로젝트 검색 성공",
-                projectService.searchProjects(memberId, keyword)));
+                projectService.searchProjects(memberId, userDetails, keyword)));
     }
 
     // todo: 해당 기능은 Project가 아닌 Member의 책임이 아닐까?
@@ -73,7 +73,7 @@ public class ProjectController {
     @PostMapping("/v1/projects")
     @Operation(summary = "프로젝트 생성", description = "")
     public ResponseEntity<CommonResponse<?>> createProject(@RequestBody ProjectCreateUpdateRequest request,
-                                                        @AuthenticationPrincipal UserDetails userDetails) {
+                                                           @AuthenticationPrincipal UserDetails userDetails) {
         projectService.createProject(request, userDetails);
         return ResponseEntity.ok().body(CommonResponse.success("프로젝트 생성 성공", null));
     }

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
@@ -33,25 +33,25 @@ public class ProjectController {
 
     @GetMapping("/v1/projects/members/{memberId}")
     @Operation(summary = "소속 프로젝트 전체 조회(썸네일)", description = "")
-    public ResponseEntity<CommonResponse<?>> findProjects(@PathVariable Long memberId, @AuthenticationPrincipal UserDetails userDetails) {
+    public ResponseEntity<CommonResponse<?>> findProjects(@PathVariable Long memberId) {
         return ResponseEntity.ok().body(CommonResponse.success("프로젝트 목록 조회 성공",
-                projectService.findProjects(memberId, userDetails)));
+                projectService.findProjects(memberId)));
     }
 
     // todo: Schedule 조회 로직의 작성이 선행되야 합니다.
     @GetMapping("/v1/projects/members/{memberId}/pin")
     @Operation(summary = "핀 설정된 프로젝트 조회(+시간표)", description = "")
-    public ResponseEntity<CommonResponse<?>> findPinProjects(@PathVariable Long memberId, @AuthenticationPrincipal UserDetails userDetails) {
+    public ResponseEntity<CommonResponse<?>> findPinProjects(@PathVariable Long memberId) {
         return ResponseEntity.ok().body(CommonResponse.success("핀 설정된 프로젝트 조회 성공",
-                projectService.findPinProjects(memberId, userDetails)));
+                projectService.findPinProjects(memberId)));
     }
 
     @GetMapping("/v1/projects/members/{memberId}/{keyword}")
     @Operation(summary = "유저가 가지고 있는 프로젝트 중 검색", description = "")
-    public ResponseEntity<CommonResponse<?>> searchProjects(@PathVariable Long memberId, @AuthenticationPrincipal UserDetails userDetails,
+    public ResponseEntity<CommonResponse<?>> searchProjects(@PathVariable Long memberId,
                                                             @PathVariable String keyword) {
         return ResponseEntity.ok().body(CommonResponse.success("프로젝트 검색 성공",
-                projectService.searchProjects(memberId, userDetails, keyword)));
+                projectService.searchProjects(memberId, keyword)));
     }
 
     // todo: 해당 기능은 Project가 아닌 Member의 책임이 아닐까?

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
@@ -19,6 +19,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.*;
 
+import static java.util.Objects.requireNonNull;
+
+
 @Slf4j
 @Service
 @RequiredArgsConstructor


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
close #45 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

본인의 페이지에만 접근 가능하도록 로직을 변경했습니다.


### 스크린샷 (선택)
![image](https://github.com/Your-Lie-in-April/server/assets/92552047/e26c8d05-7f4b-4ad1-8295-9986ae1db27d)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
저희가 확장성을 생각해서 유저 정보 확인 같은거에 memberId를 넣도록 했는데 여기에 본인만 접근 가능하게 하면 어불성설이 되지 않을까 싶은 생각이 들어서 일단 유저 정보확인을 제외한 프로젝트 API에만 본인 확인 로직을 넣었습니다.
