### PR TITLE
fix: reissue 기능의 url를 명세와 동일하게 변경#57

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/AuthController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/AuthController.java
@@ -19,26 +19,26 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v1/oauth2")
+@RequestMapping("")
 public class AuthController {
 
     private final AuthService authService;
 
-    @GetMapping(value = "/reissue")
+    @GetMapping(value = "/v1/auth/reissue")
     @Operation(summary = "토큰 재발급", description = "")
     @SwaggerApiResponses
     public ResponseEntity<CommonResponse> reissueAccessToken(HttpServletRequest request) {
         return ResponseEntity.status(HttpStatus.OK).body(new CommonResponse(1, "토큰 재발급 성공", authService.reissueAccessToken(request)));
     }
 
-    @GetMapping(value = "/test")
+    @GetMapping(value = "/v1/auth/test")
     @Operation(summary = "테스트API", description = "")
     @SwaggerApiResponses
     public ResponseEntity<CommonResponse> testApi(@AuthenticationPrincipal UserDetails userDetails) {
         return ResponseEntity.status(HttpStatus.OK).body(new CommonResponse(1, "테스트 성공", authService.testApi(userDetails)));
     }
 
-    @GetMapping(value = "/test1")
+    @GetMapping(value = "/v1/auth/test1")
     @Operation(summary = "테스트API", description = "")
     @SwaggerApiResponses
     public ResponseEntity<CommonResponse> testApi1(@AuthenticationPrincipal UserDetails userDetails) {


### PR DESCRIPTION
## #️⃣연관된 이슈

close #57

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

reissue 기능의 url를 `v1/oauth2/reissue` -> `v1/auth/reissue` 로 변경했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
