### PR TITLE
스케줄 CRUD API 추가

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/common/exception/ExceptionMessage.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/exception/ExceptionMessage.java
@@ -11,14 +11,23 @@ public enum ExceptionMessage {
     TOKEN_NOT_FOUND("토큰이 비었거나 null입니다", 0, HttpStatus.BAD_REQUEST),
     TOKEN_TYPE_INVALID("토큰 타입이 틀렸습니다.", 0, HttpStatus.BAD_REQUEST),
     MEMBER_PROJECT_NOT_FOUND("멤버-프로젝트가 존재하지 않습니다.", 0, HttpStatus.NOT_FOUND),
+    MEMBER_UNAUTHENTICATED("접근 권한이 없는 페이지입니다.", 0, HttpStatus.UNAUTHORIZED),
     PROJECT_NOT_FOUND("프로젝트가 존재하지 않습니다.", 0, HttpStatus.NOT_FOUND),
+    IS_NOT_SAME_DAY("startTime과 endTime의 날짜가 다름", 0, HttpStatus.BAD_REQUEST),
+    INVALID_PROJECT_DAY_OF_WEEK("프로젝트 수행일이 아님", 0, HttpStatus.BAD_REQUEST),
+    INVALID_TIME_SEQUENCE("startTime이 endTime 이후일 수 없습니다.", 0, HttpStatus.BAD_REQUEST),
+    INVALID_PROJECT_TIME("스케줄 작성 요청이 프로젝트 수행 시간을 벗어납니다.", 0, HttpStatus.BAD_REQUEST),
+    INVALID_PROJECT_PERIOD("스케줄 작성 요청이 프로젝트 수행 기간을 벗어납니다.", 0, HttpStatus.BAD_REQUEST),
+    INVALID_TIME_UNIT("스케줄 요청은 30분 단위의 시간이어야 합니다.", 0, HttpStatus.BAD_REQUEST),
+    INVALID_DATE("ScheduleDayRequest에 속한 모든 요청은 같은 날짜여야 합니다.", 0, HttpStatus.BAD_REQUEST),
+    DUPLICATE_DATE("스케줄 생성 요청에 중복된 날짜가 존재합니다.", 0, HttpStatus.BAD_REQUEST),
+    INVALID_WEEK("스케줄 생성 요청이 일주일 범위를 초과합니다.", 0, HttpStatus.BAD_REQUEST),
     KICK_ADMIN("프로젝트 관리자는 강퇴할 수 없습니다", 0, HttpStatus.BAD_REQUEST),
     LINK_EXPIRED("초대링크의 유효날짜가 지났습니다.", 0, HttpStatus.BAD_REQUEST),
     DUPLICATE_SIGN_REQUEST("중복된 가입요청입니다.", 0, HttpStatus.BAD_REQUEST),
     INSUFFICIENT_PRIVILEGE("프로젝트 관리자 권한이 없습니다.", 0, HttpStatus.BAD_REQUEST),
     ADMIN_LEAVE("관리자는 나갈 수 없습니다", 0, HttpStatus.BAD_REQUEST),
-    NOT_MEMBER("속하지 않은 프로젝트 정보를 조회할 수 없습니다.", 0, HttpStatus.BAD_REQUEST),
-    MEMBER_UNAUTHENTICATED("접근 권한이 없는 페이지입니다.", 0, HttpStatus.UNAUTHORIZED);
+    NOT_MEMBER("속하지 않은 프로젝트 정보를 조회할 수 없습니다.", 0, HttpStatus.BAD_REQUEST);
 
 
     private final String message;

--- a/timepiece/src/main/java/com/appcenter/timepiece/common/exception/ExceptionMessage.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/exception/ExceptionMessage.java
@@ -27,7 +27,8 @@ public enum ExceptionMessage {
     DUPLICATE_SIGN_REQUEST("중복된 가입요청입니다.", 0, HttpStatus.BAD_REQUEST),
     INSUFFICIENT_PRIVILEGE("프로젝트 관리자 권한이 없습니다.", 0, HttpStatus.BAD_REQUEST),
     ADMIN_LEAVE("관리자는 나갈 수 없습니다", 0, HttpStatus.BAD_REQUEST),
-    NOT_MEMBER("속하지 않은 프로젝트 정보를 조회할 수 없습니다.", 0, HttpStatus.BAD_REQUEST);
+    NOT_MEMBER("속하지 않은 프로젝트 정보를 조회할 수 없습니다.", 0, HttpStatus.BAD_REQUEST),
+    INTERSECT_TIME("ScheduleDto 간 중복/교차되는 시간이 들어왔습니다.", 0, HttpStatus.BAD_REQUEST);
 
 
     private final String message;

--- a/timepiece/src/main/java/com/appcenter/timepiece/common/security/JwtProvider.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/security/JwtProvider.java
@@ -18,11 +18,9 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import java.nio.charset.StandardCharsets;
-import java.text.SimpleDateFormat;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
-import java.util.Locale;
 
 @Service
 @Slf4j
@@ -70,11 +68,6 @@ public class JwtProvider {
         claims.put("type", "access");
 
         Date now = new Date();
-        
-        SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd");
-        System.out.println(format.format(now)); // 20090529
-        format = new SimpleDateFormat("E MMM dd HH:mm:ss", Locale.KOREA);
-        System.out.println(format.format(now));
 
         String token = Jwts.builder()
                 .setClaims(claims)

--- a/timepiece/src/main/java/com/appcenter/timepiece/common/security/SecurityConfig.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/security/SecurityConfig.java
@@ -59,6 +59,7 @@ public class SecurityConfig {
                         .requestMatchers("/v1/oauth2/test1").permitAll()
                         .requestMatchers("/v1/projects/**").hasRole("USER")
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/v1/projects/**").hasRole("USER")
                         .requestMatchers("/login/**").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
@@ -38,7 +38,6 @@ public class ProjectController {
                 projectService.findProjects(memberId, userDetails)));
     }
 
-    // todo: Schedule 조회 로직의 작성이 선행되야 합니다.
     @GetMapping("/v1/projects/members/{memberId}/pin")
     @Operation(summary = "핀 설정된 프로젝트 조회(+시간표)", description = "")
     public ResponseEntity<CommonResponse<?>> findPinProjects(@PathVariable Long memberId, @AuthenticationPrincipal UserDetails userDetails) {

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
@@ -33,25 +33,25 @@ public class ProjectController {
 
     @GetMapping("/v1/projects/members/{memberId}")
     @Operation(summary = "소속 프로젝트 전체 조회(썸네일)", description = "")
-    public ResponseEntity<CommonResponse<?>> findProjects(@PathVariable Long memberId) {
+    public ResponseEntity<CommonResponse<?>> findProjects(@PathVariable Long memberId, @AuthenticationPrincipal UserDetails userDetails) {
         return ResponseEntity.ok().body(CommonResponse.success("프로젝트 목록 조회 성공",
-                projectService.findProjects(memberId)));
+                projectService.findProjects(memberId, userDetails)));
     }
 
     // todo: Schedule 조회 로직의 작성이 선행되야 합니다.
     @GetMapping("/v1/projects/members/{memberId}/pin")
     @Operation(summary = "핀 설정된 프로젝트 조회(+시간표)", description = "")
-    public ResponseEntity<CommonResponse<?>> findPinProjects(@PathVariable Long memberId) {
+    public ResponseEntity<CommonResponse<?>> findPinProjects(@PathVariable Long memberId, @AuthenticationPrincipal UserDetails userDetails) {
         return ResponseEntity.ok().body(CommonResponse.success("핀 설정된 프로젝트 조회 성공",
-                projectService.findPinProjects(memberId)));
+                projectService.findPinProjects(memberId, userDetails)));
     }
 
     @GetMapping("/v1/projects/members/{memberId}/{keyword}")
     @Operation(summary = "유저가 가지고 있는 프로젝트 중 검색", description = "")
-    public ResponseEntity<CommonResponse<?>> searchProjects(@PathVariable Long memberId,
+    public ResponseEntity<CommonResponse<?>> searchProjects(@PathVariable Long memberId, @AuthenticationPrincipal UserDetails userDetails,
                                                             @PathVariable String keyword) {
         return ResponseEntity.ok().body(CommonResponse.success("프로젝트 검색 성공",
-                projectService.searchProjects(memberId, keyword)));
+                projectService.searchProjects(memberId, userDetails, keyword)));
     }
 
     // todo: 해당 기능은 Project가 아닌 Member의 책임이 아닐까?

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ScheduleController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ScheduleController.java
@@ -5,6 +5,7 @@ import com.appcenter.timepiece.dto.schedule.ScheduleCreateUpdateRequest;
 import com.appcenter.timepiece.dto.schedule.ScheduleDeleteRequest;
 import com.appcenter.timepiece.service.ScheduleService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -34,7 +35,7 @@ public class ScheduleController {
                                                     "일요일-토요일까지 일주일 스케줄을 조회합니다. " +
                                                     "condition이 포함된 주차를 조회합니다.")
     public CommonResponse<List<?>> findMembersSchedules(@PathVariable Long projectId,
-                                                        @RequestParam LocalDate condition,
+                                                        @RequestParam @Schema(example = "2024-02-01") LocalDate condition,
                                                         @AuthenticationPrincipal UserDetails userDetails) {
         return CommonResponse.success("성공", scheduleService.findMembersSchedules(projectId, condition, userDetails));
     }
@@ -55,7 +56,7 @@ public class ScheduleController {
                                                     "condition이 포함된 주차를 조회합니다.")
     public CommonResponse<?> findSchedule(@PathVariable Long projectId,
                                           @PathVariable Long memberId,
-                                          @RequestParam LocalDate condition,
+                                          @RequestParam @Schema(example = "2024-02-01") LocalDate condition,
                                           @AuthenticationPrincipal UserDetails userDetails) {
         return CommonResponse.success("성공", scheduleService.findSchedule(projectId, memberId, condition, userDetails));
     }

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ScheduleController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ScheduleController.java
@@ -3,24 +3,37 @@ package com.appcenter.timepiece.controller;
 import com.appcenter.timepiece.common.dto.CommonResponse;
 import com.appcenter.timepiece.dto.schedule.ScheduleCreateUpdateRequest;
 import com.appcenter.timepiece.dto.schedule.ScheduleDeleteRequest;
+import com.appcenter.timepiece.service.ScheduleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequiredArgsConstructor
 public class ScheduleController {
 
+    private final ScheduleService scheduleService;
+
+    //현재 ScheduleCreateUpdateRequest에서 projectId를 이미 받고있는데 @pathvariable로 또 받고있습니다. 수정이 필요해보입니다.
     @PostMapping("/v1/projects/{projectId}/schedules")
-    public ResponseEntity<CommonResponse<?>> createSchedule(@RequestBody ScheduleCreateUpdateRequest request) {
-        return null;
+    public ResponseEntity<CommonResponse<?>> createSchedule(@RequestBody ScheduleCreateUpdateRequest request
+            , @PathVariable Long projectId, @AuthenticationPrincipal UserDetails userDetails) {
+        scheduleService.createSchedule(request, projectId, userDetails);
+        return ResponseEntity.status(HttpStatus.CREATED).body(CommonResponse.success("성공", null));
     }
 
     @PutMapping("/v1/projects/{projectId}/schedules")
-    public ResponseEntity<CommonResponse<?>> updateSchedule(@RequestBody ScheduleCreateUpdateRequest request) {
+    public ResponseEntity<CommonResponse<?>> updateSchedule(@RequestBody ScheduleCreateUpdateRequest request
+            , @PathVariable Long projectId, @AuthenticationPrincipal UserDetails userDetails) {
         return null;
     }
 
     @DeleteMapping("/v1/projects/{projectId}/schedules")
-    public ResponseEntity<CommonResponse<?>> deleteSchedule(@RequestBody ScheduleDeleteRequest request) {
+    public ResponseEntity<CommonResponse<?>> deleteSchedule(@RequestBody ScheduleDeleteRequest request
+            , @PathVariable Long projectId, @AuthenticationPrincipal UserDetails userDetails) {
         return null;
     }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ScheduleController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ScheduleController.java
@@ -4,6 +4,7 @@ import com.appcenter.timepiece.common.dto.CommonResponse;
 import com.appcenter.timepiece.dto.schedule.ScheduleCreateUpdateRequest;
 import com.appcenter.timepiece.dto.schedule.ScheduleDeleteRequest;
 import com.appcenter.timepiece.service.ScheduleService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,16 +22,6 @@ public class ScheduleController {
     private final ScheduleService scheduleService;
 
     /**
-     * For Test During Develop
-     *
-     * @return CommonResponse<List < ScheduleWeekResponse>>
-     */
-    @GetMapping("/v1/schedules/all")
-    public CommonResponse<?> findAllSchedules() {
-        return CommonResponse.success("성공", null);
-    }
-
-    /**
      * {@summary 인증 성공 시 프로젝트 내 모든 사용자 시간표 조회}
      * <p>프로젝트에 속해있는 모든 사용자의 시간표 정보{@literal ((List<ScheduleWeekResponse>) 반환}
      *
@@ -39,6 +30,9 @@ public class ScheduleController {
      * @return {@literal List<ScheduleWeekResponse>}
      */
     @GetMapping("/v1/projects/{projectId}/schedules")
+    @Operation(summary = "프로젝트 범위 스케줄 조회", description = "프로젝트 내 모든 구성원의 스케줄을 조회합니다. " +
+                                                    "일요일-토요일까지 일주일 스케줄을 조회합니다. " +
+                                                    "condition이 포함된 주차를 조회합니다.")
     public CommonResponse<List<?>> findMembersSchedules(@PathVariable Long projectId,
                                                         @RequestParam LocalDate condition,
                                                         @AuthenticationPrincipal UserDetails userDetails) {
@@ -56,6 +50,9 @@ public class ScheduleController {
      * @return {@literal CommmonResponse<ScheduleWeekResponse>}
      */
     @GetMapping("/v1/projects/{projectId}/members/{memberId}/schedules")
+    @Operation(summary = "단일 멤버 스케줄 조회", description = "특정 멤버의 스케줄을 조회합니다. " +
+                                                    "일요일-토요일까지 일주일 스케줄을 조회합니다. " +
+                                                    "condition이 포함된 주차를 조회합니다.")
     public CommonResponse<?> findSchedule(@PathVariable Long projectId,
                                           @PathVariable Long memberId,
                                           @RequestParam LocalDate condition,
@@ -73,6 +70,9 @@ public class ScheduleController {
      * @return
      */
     @PostMapping("/v1/projects/{projectId}/schedules")
+    @Operation(summary = "스케줄 생성", description = "스케줄을 생성합니다." +
+                                                 "일반적인 사용흐름으로는 주 단위로 추가되지만," +
+                                                 "몇 주에 걸친 스케줄 데이터도 한 번에 저장할 수 있습니다.")
     public ResponseEntity<CommonResponse<?>> createSchedule(@PathVariable Long projectId,
                                                             @RequestBody ScheduleCreateUpdateRequest request,
                                                             @AuthenticationPrincipal UserDetails userDetails) {
@@ -90,6 +90,8 @@ public class ScheduleController {
      * @return
      */
     @PutMapping("/v1/projects/{projectId}/schedules")
+    @Operation(summary = "스케줄 변경", description = "기존 스케줄을 삭제하고 새로운 스케줄을 저장합니다." +
+                                                    "주 단위(일요일-토요일)로만 정상적으로 동작합니다.")
     public ResponseEntity<CommonResponse<?>> updateSchedule(@PathVariable Long projectId,
                                                             @RequestBody ScheduleCreateUpdateRequest request,
                                                             @AuthenticationPrincipal UserDetails userDetails) {
@@ -106,6 +108,8 @@ public class ScheduleController {
      * @param userDetails JWT 인증 시, SecurityContext에 저장된 사용자 정보
      * @return
      */
+    @Operation(summary = "스케줄 삭제", description = "지정된 범위(기간)의 스케줄을 삭제합니다." +
+                                                 "startDate는 포함, endDate는 포함하지 않습니다.")
     @DeleteMapping("/v1/projects/{projectId}/schedules")
     public ResponseEntity<CommonResponse<?>> deleteSchedule(@PathVariable Long projectId,
                                                             @RequestBody ScheduleDeleteRequest request,

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ScheduleController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ScheduleController.java
@@ -11,29 +11,106 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 public class ScheduleController {
 
     private final ScheduleService scheduleService;
 
-    //현재 ScheduleCreateUpdateRequest에서 projectId를 이미 받고있는데 @pathvariable로 또 받고있습니다. 수정이 필요해보입니다.
+    /**
+     * For Test During Develop
+     *
+     * @return CommonResponse<List < ScheduleWeekResponse>>
+     */
+    @GetMapping("/v1/schedules/all")
+    public CommonResponse<?> findAllSchedules() {
+        return CommonResponse.success("성공", null);
+    }
+
+    /**
+     * {@summary 인증 성공 시 프로젝트 내 모든 사용자 시간표 조회}
+     * <p>프로젝트에 속해있는 모든 사용자의 시간표 정보{@literal ((List<ScheduleWeekResponse>) 반환}
+     *
+     * @param projectId   프로젝트 식별자
+     * @param userDetails JWT 인증 시, SecurityContext에 저장된 사용자 정보
+     * @return {@literal List<ScheduleWeekResponse>}
+     */
+    @GetMapping("/v1/projects/{projectId}/schedules")
+    public CommonResponse<List<?>> findMembersSchedules(@PathVariable Long projectId,
+                                                        @RequestParam LocalDate condition,
+                                                        @AuthenticationPrincipal UserDetails userDetails) {
+        return CommonResponse.success("성공", scheduleService.findMembersSchedules(projectId, condition, userDetails));
+    }
+
+    /**
+     * {@summary 인증 성공 시, 특정 프로젝트-특정 사용자의 시간표 조회}
+     * <p> projectId에 속하는 프로젝트 내에서 memberId와 일치하는 사용자의 일주일 스케줄을 조회한다.
+     * 속해있지 않은 프로젝트에 작성된 스케줄은 조회하지 못하고, 내가 현재 속해있는 프로젝트 안에서만 사용가능하다.
+     *
+     * @param projectId   프로젝트 식별자
+     * @param memberId    멤버 식별자
+     * @param userDetails JWT 인증 시, SecurityContext에 저장된 사용자 정보
+     * @return {@literal CommmonResponse<ScheduleWeekResponse>}
+     */
+    @GetMapping("/v1/projects/{projectId}/members/{memberId}/schedules")
+    public CommonResponse<?> findSchedule(@PathVariable Long projectId,
+                                          @PathVariable Long memberId,
+                                          @RequestParam LocalDate condition,
+                                          @AuthenticationPrincipal UserDetails userDetails) {
+        return CommonResponse.success("성공", scheduleService.findSchedule(projectId, memberId, condition, userDetails));
+    }
+
+    /**
+     * {@summary 인증이 성공하면 request에 맞춰 스케줄을 생성한다.}
+     * <p>
+     *
+     * @param request     스케줄 생성 및 삭제 요청 시, 사용되는 DTO(ScheduleCreateUpdateRequest)
+     * @param projectId   프로젝트 식별자
+     * @param userDetails JWT 인증 시, SecurityContext에 저장된 사용자 정보
+     * @return
+     */
     @PostMapping("/v1/projects/{projectId}/schedules")
-    public ResponseEntity<CommonResponse<?>> createSchedule(@RequestBody ScheduleCreateUpdateRequest request
-            , @PathVariable Long projectId, @AuthenticationPrincipal UserDetails userDetails) {
+    public ResponseEntity<CommonResponse<?>> createSchedule(@PathVariable Long projectId,
+                                                            @RequestBody ScheduleCreateUpdateRequest request,
+                                                            @AuthenticationPrincipal UserDetails userDetails) {
         scheduleService.createSchedule(request, projectId, userDetails);
         return ResponseEntity.status(HttpStatus.CREATED).body(CommonResponse.success("성공", null));
     }
 
+    /**
+     * {@summary 인증이 성공하면 request에 맞춰 스케줄을 수정한다.}
+     * <p>
+     *
+     * @param request     스케줄 생성 및 삭제 요청 시, 사용되는 DTO(ScheduleCreateUpdateRequest)
+     * @param projectId   프로젝트 식별자
+     * @param userDetails JWT 인증 시, SecurityContext에 저장된 사용자 정보
+     * @return
+     */
     @PutMapping("/v1/projects/{projectId}/schedules")
-    public ResponseEntity<CommonResponse<?>> updateSchedule(@RequestBody ScheduleCreateUpdateRequest request
-            , @PathVariable Long projectId, @AuthenticationPrincipal UserDetails userDetails) {
-        return null;
+    public ResponseEntity<CommonResponse<?>> updateSchedule(@PathVariable Long projectId,
+                                                            @RequestBody ScheduleCreateUpdateRequest request,
+                                                            @AuthenticationPrincipal UserDetails userDetails) {
+        scheduleService.editSchedule(request, projectId, userDetails);
+        return ResponseEntity.ok().body(CommonResponse.success("성공", null));
     }
 
+    /**
+     * {@summary 인증이 성공하면 request에 맞춰 스케줄을 삭제한다.}
+     * <p>
+     *
+     * @param request
+     * @param projectId   프로젝트 식별자
+     * @param userDetails JWT 인증 시, SecurityContext에 저장된 사용자 정보
+     * @return
+     */
     @DeleteMapping("/v1/projects/{projectId}/schedules")
-    public ResponseEntity<CommonResponse<?>> deleteSchedule(@RequestBody ScheduleDeleteRequest request
-            , @PathVariable Long projectId, @AuthenticationPrincipal UserDetails userDetails) {
-        return null;
+    public ResponseEntity<CommonResponse<?>> deleteSchedule(@PathVariable Long projectId,
+                                                            @RequestBody ScheduleDeleteRequest request,
+                                                            @AuthenticationPrincipal UserDetails userDetails) {
+        scheduleService.deleteSchedule(request, projectId, userDetails);
+        return ResponseEntity.ok().body(CommonResponse.success("성공", null));
     }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ScheduleController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ScheduleController.java
@@ -70,9 +70,7 @@ public class ScheduleController {
      * @return
      */
     @PostMapping("/v1/projects/{projectId}/schedules")
-    @Operation(summary = "스케줄 생성", description = "스케줄을 생성합니다." +
-                                                 "일반적인 사용흐름으로는 주 단위로 추가되지만," +
-                                                 "몇 주에 걸친 스케줄 데이터도 한 번에 저장할 수 있습니다.")
+    @Operation(summary = "스케줄 생성", description = "스케줄을 생성합니다. 주 단위(일요일-토요일)로만 동작합니다.")
     public ResponseEntity<CommonResponse<?>> createSchedule(@PathVariable Long projectId,
                                                             @RequestBody ScheduleCreateUpdateRequest request,
                                                             @AuthenticationPrincipal UserDetails userDetails) {
@@ -91,7 +89,7 @@ public class ScheduleController {
      */
     @PutMapping("/v1/projects/{projectId}/schedules")
     @Operation(summary = "스케줄 변경", description = "기존 스케줄을 삭제하고 새로운 스케줄을 저장합니다." +
-                                                    "주 단위(일요일-토요일)로만 정상적으로 동작합니다.")
+                                                    "주 단위(일요일-토요일)로만 동작합니다.")
     public ResponseEntity<CommonResponse<?>> updateSchedule(@PathVariable Long projectId,
                                                             @RequestBody ScheduleCreateUpdateRequest request,
                                                             @AuthenticationPrincipal UserDetails userDetails) {
@@ -108,8 +106,7 @@ public class ScheduleController {
      * @param userDetails JWT 인증 시, SecurityContext에 저장된 사용자 정보
      * @return
      */
-    @Operation(summary = "스케줄 삭제", description = "지정된 범위(기간)의 스케줄을 삭제합니다." +
-                                                 "startDate는 포함, endDate는 포함하지 않습니다.")
+    @Operation(summary = "스케줄 삭제", description = "지정된 범위(startDate <= target < endDate)의 스케줄을 삭제합니다.")
     @DeleteMapping("/v1/projects/{projectId}/schedules")
     public ResponseEntity<CommonResponse<?>> deleteSchedule(@PathVariable Long projectId,
                                                             @RequestBody ScheduleDeleteRequest request,

--- a/timepiece/src/main/java/com/appcenter/timepiece/domain/Project.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/domain/Project.java
@@ -8,10 +8,12 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -38,13 +40,10 @@ public class Project extends BaseTimeEntity {
     @Column(name = "end_time")
     private LocalTime endTime;
 
-    private Boolean mon;
-    private Boolean tue;
-    private Boolean wed;
-    private Boolean thu;
-    private Boolean fri;
-    private Boolean sat;
-    private Boolean sun;
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name="project_days_of_week",
+            joinColumns = @JoinColumn(name= "project_id"))
+    private Set<DayOfWeek> daysOfWeek;
 
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL)
     private List<MemberProject> memberProjects = new ArrayList<>();
@@ -61,8 +60,7 @@ public class Project extends BaseTimeEntity {
     @Builder(access = AccessLevel.PRIVATE)
     private Project(String title, String description,
                     LocalDate startDate, LocalDate endDate, LocalTime startTime, LocalTime endTime,
-                    Boolean mon, Boolean tue, Boolean wed, Boolean thu, Boolean fri, Boolean sat, Boolean sun,
-                    List<MemberProject> memberProjects, List<Invitation> invitations,
+                    Set<DayOfWeek> daysOfWeek, List<MemberProject> memberProjects, List<Invitation> invitations,
                     Cover cover, String color) {
         this.title = title;
         this.description = description;
@@ -70,13 +68,7 @@ public class Project extends BaseTimeEntity {
         this.endDate = endDate;
         this.startTime = startTime;
         this.endTime = endTime;
-        this.mon = mon;
-        this.tue = tue;
-        this.wed = wed;
-        this.thu = thu;
-        this.fri = fri;
-        this.sat = sat;
-        this.sun = sun;
+        this.daysOfWeek = daysOfWeek;
         this.memberProjects = memberProjects;
         this.invitations = invitations;
         this.cover = cover;
@@ -89,8 +81,7 @@ public class Project extends BaseTimeEntity {
                 .description(request.getDescription())
                 .startDate(request.getStartDate()).endDate(request.getEndDate())
                 .startTime(request.getStartTime()).endTime(request.getEndTime())
-                .mon(request.getMon()).tue(request.getTue()).wed(request.getWed())
-                .thu(request.getThu()).fri(request.getFri()).sat(request.getSat()).sun(request.getSun())
+                .daysOfWeek(request.getDaysOfWeek())
                 .color(request.getColor())
                 .cover(cover)
                 .build();
@@ -103,13 +94,7 @@ public class Project extends BaseTimeEntity {
         this.endDate = request.getEndDate();
         this.startTime = request.getStartTime();
         this.endTime = request.getEndTime();
-        this.mon = request.getMon();
-        this.tue = request.getTue();
-        this.wed = request.getWed();
-        this.thu = request.getThu();
-        this.fri = request.getFri();
-        this.sat = request.getSat();
-        this.sun = request.getSun();
+        this.daysOfWeek = request.getDaysOfWeek();
         this.color = request.getColor();
         this.cover = cover;
     }

--- a/timepiece/src/main/java/com/appcenter/timepiece/domain/Project.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/domain/Project.java
@@ -58,7 +58,7 @@ public class Project extends BaseTimeEntity {
 
     private String color;
 
-    @Builder(access = AccessLevel.PRIVATE)
+    @Builder
     private Project(String title, String description,
                     LocalDate startDate, LocalDate endDate, LocalTime startTime, LocalTime endTime,
                     Set<DayOfWeek> daysOfWeek, List<MemberProject> memberProjects, List<Invitation> invitations,

--- a/timepiece/src/main/java/com/appcenter/timepiece/domain/Project.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/domain/Project.java
@@ -40,6 +40,7 @@ public class Project extends BaseTimeEntity {
     @Column(name = "end_time")
     private LocalTime endTime;
 
+    @Enumerated(EnumType.STRING)
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name="project_days_of_week",
             joinColumns = @JoinColumn(name= "project_id"))

--- a/timepiece/src/main/java/com/appcenter/timepiece/domain/Schedule.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/domain/Schedule.java
@@ -1,16 +1,20 @@
 package com.appcenter.timepiece.domain;
 
 import com.appcenter.timepiece.common.BaseTimeEntity;
+import com.appcenter.timepiece.dto.schedule.ScheduleDto;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Slf4j
 public class Schedule extends BaseTimeEntity {
 
     @Id
@@ -27,4 +31,19 @@ public class Schedule extends BaseTimeEntity {
 
     @Column(name = "end_time")
     private LocalDateTime endTime;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Schedule(MemberProject memberProject, LocalDateTime startTime, LocalDateTime endTime) {
+        this.memberProject = memberProject;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public static Schedule of(ScheduleDto scheduleDto, MemberProject memberProject) {
+        return Schedule.builder()
+                .memberProject(memberProject)
+                .startTime(scheduleDto.getStartTime())
+                .endTime(scheduleDto.getEndTime())
+                .build();
+    }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/member/UpdateNicknameRequest.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/member/UpdateNicknameRequest.java
@@ -17,4 +17,8 @@ public class UpdateNicknameRequest {
     @Schema(description = "변경할 닉네임(To)", example = "나무")
     private String nickname;
 
+    public UpdateNicknameRequest(Long projectId, String nickname) {
+        this.projectId = projectId;
+        this.nickname = nickname;
+    }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/project/PinProjectResponse.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/project/PinProjectResponse.java
@@ -6,9 +6,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Set;
 
 @Getter
 public class PinProjectResponse {
@@ -27,19 +29,7 @@ public class PinProjectResponse {
 
     private LocalTime endTime;
 
-    private Boolean mon;
-
-    private Boolean tue;
-
-    private Boolean wed;
-
-    private Boolean thu;
-
-    private Boolean fri;
-
-    private Boolean sat;
-
-    private Boolean sun;
+    private Set<DayOfWeek> daysOfWeek;
 
     private String color;
 
@@ -52,7 +42,7 @@ public class PinProjectResponse {
     @Builder(access = AccessLevel.PRIVATE)
     private PinProjectResponse(Long projectId, String title, String description, LocalDate startDate, LocalDate endDate,
                                LocalTime startTime, LocalTime endTime,
-                               Boolean mon, Boolean tue, Boolean wed, Boolean thu, Boolean fri, Boolean sat, Boolean sun,
+                               Set<DayOfWeek> daysOfWeek,
                                String color, String coverImageUrl,
                                Integer memberCount, List<ScheduleWeekResponse> schedule) {
         this.projectId = projectId;
@@ -62,13 +52,7 @@ public class PinProjectResponse {
         this.endDate = endDate;
         this.startTime = startTime;
         this.endTime = endTime;
-        this.mon = mon;
-        this.tue = tue;
-        this.wed = wed;
-        this.thu = thu;
-        this.fri = fri;
-        this.sat = sat;
-        this.sun = sun;
+        this.daysOfWeek = daysOfWeek;
         this.color = color;
         this.coverImageUrl = coverImageUrl;
         this.memberCount = memberCount;
@@ -84,13 +68,7 @@ public class PinProjectResponse {
                 .endDate(project.getEndDate())
                 .startTime(project.getStartTime())
                 .endTime(project.getEndTime())
-                .mon(project.getMon())
-                .tue(project.getTue())
-                .wed(project.getWed())
-                .thu(project.getThu())
-                .fri(project.getFri())
-                .sat(project.getSat())
-                .sun(project.getSun())
+                .daysOfWeek(project.getDaysOfWeek())
                 .coverImageUrl(coverImageUrl)
                 .color(project.getColor())
                 .memberCount(schedule.size())

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/project/ProjectCreateUpdateRequest.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/project/ProjectCreateUpdateRequest.java
@@ -5,15 +5,17 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Set;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Schema(description = "프로젝트 생성 및 수정 요청",
         requiredProperties = {
                 "title", "description", "startDate", "endDate",
-                "startTime", "endTime", "mon", "tue", "wed", "thu", "fri", "sat", "sun",
+                "startTime", "endTime", "daysOfWeek",
                 "isStored", "color", "coverId"})
 public class ProjectCreateUpdateRequest {
 
@@ -35,26 +37,8 @@ public class ProjectCreateUpdateRequest {
     @Schema(description = "프로젝트 종료 시간", example = "22:00:00", type = "String", pattern = "HH:mm:ss")
     private LocalTime endTime;
 
-    @Schema(description = "월요일", example = "true")
-    private Boolean mon;
-
-    @Schema(description = "화요일", example = "true")
-    private Boolean tue;
-
-    @Schema(description = "수요일", example = "true")
-    private Boolean wed;
-
-    @Schema(description = "목요일", example = "true")
-    private Boolean thu;
-
-    @Schema(description = "금요일", example = "true")
-    private Boolean fri;
-
-    @Schema(description = "토요일", example = "false")
-    private Boolean sat;
-
-    @Schema(description = "일요일", example = "false")
-    private Boolean sun;
+    @Schema(description = "요일", example = "[\"MONDAY\", \"TUESDAY\", \"WEDNESDAY\", \"THURSDAY\", \"FRIDAY\"]")
+    private Set<DayOfWeek> daysOfWeek;
 
     @Schema(description = "보관여부", example = "false")
     private Boolean isStored;

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/project/ProjectCreateUpdateRequest.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/project/ProjectCreateUpdateRequest.java
@@ -2,6 +2,7 @@ package com.appcenter.timepiece.dto.project;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -49,4 +50,20 @@ public class ProjectCreateUpdateRequest {
     @Schema(description = "커버가 저장된 URL",
             example = "https://cover-images.inuappcenter.com/121238128/308169809-wf61e-49f5-a5fa-2")
     private String coverImageUrl;
+
+    @Builder
+    private ProjectCreateUpdateRequest(String title, String description, LocalDate startDate, LocalDate endDate,
+                                      LocalTime startTime, LocalTime endTime, Set<DayOfWeek> daysOfWeek,
+                                      Boolean isStored, String color, String coverImageUrl) {
+        this.title = title;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.daysOfWeek = daysOfWeek;
+        this.isStored = isStored;
+        this.color = color;
+        this.coverImageUrl = coverImageUrl;
+    }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/project/ProjectCreateUpdateRequest.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/project/ProjectCreateUpdateRequest.java
@@ -29,7 +29,7 @@ public class ProjectCreateUpdateRequest {
     @Schema(description = "프로젝트 시작일", example = "2024-01-18")
     private LocalDate startDate;
 
-    @Schema(description = "프로젝트 종료일", example = "2024-01-31")
+    @Schema(description = "프로젝트 종료일", example = "2024-02-18")
     private LocalDate endDate;
 
     @Schema(description = "프로젝트 시작 시간", example = "09:00:00", type = "String", pattern = "HH:mm:ss")
@@ -38,7 +38,7 @@ public class ProjectCreateUpdateRequest {
     @Schema(description = "프로젝트 종료 시간", example = "22:00:00", type = "String", pattern = "HH:mm:ss")
     private LocalTime endTime;
 
-    @Schema(description = "요일", example = "[\"MONDAY\", \"TUESDAY\", \"WEDNESDAY\", \"THURSDAY\", \"FRIDAY\"]")
+    @Schema(description = "요일", example = "[\"MONDAY\", \"TUESDAY\", \"WEDNESDAY\", \"THURSDAY\", \"FRIDAY\", \"SATURDAY\"]")
     private Set<DayOfWeek> daysOfWeek;
 
     @Schema(description = "보관여부", example = "false")

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/project/ProjectResponse.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/project/ProjectResponse.java
@@ -5,8 +5,10 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Set;
 
 @Getter
 public class ProjectResponse {
@@ -25,19 +27,7 @@ public class ProjectResponse {
 
     private LocalTime endTime;
 
-    private Boolean mon;
-
-    private Boolean tue;
-
-    private Boolean wed;
-
-    private Boolean thu;
-
-    private Boolean fri;
-
-    private Boolean sat;
-
-    private Boolean sun;
+    private Set<DayOfWeek> daysOfWeek;
 
     private String coverImageUrl;
 
@@ -47,8 +37,7 @@ public class ProjectResponse {
     private ProjectResponse(Long projectId, String title, String description,
                             LocalDate startDate, LocalDate endDate,
                             LocalTime startTime, LocalTime endTime,
-                            Boolean mon, Boolean tue, Boolean wed, Boolean thu, Boolean fri,
-                            Boolean sat, Boolean sun,
+                            Set<DayOfWeek> daysOfWeek,
                             String coverImageUrl, String color) {
         this.projectId = projectId;
         this.title = title;
@@ -57,13 +46,7 @@ public class ProjectResponse {
         this.endDate = endDate;
         this.startTime = startTime;
         this.endTime = endTime;
-        this.mon = mon;
-        this.tue = tue;
-        this.wed = wed;
-        this.thu = thu;
-        this.fri = fri;
-        this.sat = sat;
-        this.sun = sun;
+        this.daysOfWeek = daysOfWeek;
         this.coverImageUrl = coverImageUrl;
         this.color = color;
     }
@@ -77,13 +60,7 @@ public class ProjectResponse {
                 .endDate(project.getEndDate())
                 .startTime(project.getStartTime())
                 .endTime(project.getEndTime())
-                .mon(project.getMon())
-                .tue(project.getTue())
-                .wed(project.getWed())
-                .thu(project.getThu())
-                .fri(project.getFri())
-                .sat(project.getSat())
-                .sun(project.getSun())
+                .daysOfWeek(project.getDaysOfWeek())
                 .coverImageUrl(coverImageUrl)
                 .color(project.getColor())
                 .build();

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/project/TransferPrivilegeRequest.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/project/TransferPrivilegeRequest.java
@@ -5,4 +5,8 @@ import lombok.Getter;
 @Getter
 public class TransferPrivilegeRequest {
     Long toMemberId;
+
+    public TransferPrivilegeRequest(Long toMemberId) {
+        this.toMemberId = toMemberId;
+    }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleCreateUpdateRequest.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleCreateUpdateRequest.java
@@ -58,8 +58,7 @@ public class ScheduleCreateUpdateRequest {
     @NotNull @Size(min = 1)
     private List<ScheduleDayRequest> schedule;
 
-    public ScheduleCreateUpdateRequest(Long projectId, List<ScheduleDayRequest> schedule) {
-        this.projectId = projectId;
+    public ScheduleCreateUpdateRequest(List<ScheduleDayRequest> schedule) {
         this.schedule = schedule;
     }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleCreateUpdateRequest.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleCreateUpdateRequest.java
@@ -14,8 +14,6 @@ import java.util.List;
 @Schema(description = "스케줄 생성 및 수정 요청", requiredProperties = {"projectId", "schedule"})
 public class ScheduleCreateUpdateRequest {
 
-    private Long projectId;
-
     @Schema(description = "주 단위 스케줄", example =
             """
               [

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleCreateUpdateRequest.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleCreateUpdateRequest.java
@@ -1,6 +1,8 @@
 package com.appcenter.timepiece.dto.schedule;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -63,6 +65,11 @@ public class ScheduleCreateUpdateRequest {
                 }
               ]
             """)
+    @NotNull @Size(min = 1)
     private List<ScheduleDayRequest> schedule;
 
+    public ScheduleCreateUpdateRequest(Long projectId, List<ScheduleDayRequest> schedule) {
+        this.projectId = projectId;
+        this.schedule = schedule;
+    }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleCreateUpdateRequest.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleCreateUpdateRequest.java
@@ -27,7 +27,7 @@ public class ScheduleCreateUpdateRequest {
                     },
                     {
                       "startTime": "2024-01-31T21:30:00",
-                      "endTime": "2024-01-31T22:30:00"
+                      "endTime": "2024-01-31T22:00:00"
                     }
                   ]
                 },
@@ -52,14 +52,6 @@ public class ScheduleCreateUpdateRequest {
                     {
                       "startTime": "2024-02-03T10:30:00",
                       "endTime": "2024-02-03T11:30:00"
-                    }
-                  ]
-                },
-                {
-                  "schedule": [
-                    {
-                      "startTime": "2024-02-04T10:30:00",
-                      "endTime": "2024-02-04T11:30:00"
                     }
                   ]
                 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleCreateUpdateRequest.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleCreateUpdateRequest.java
@@ -12,24 +12,57 @@ import java.util.List;
 @Schema(description = "스케줄 생성 및 수정 요청", requiredProperties = {"projectId", "schedule"})
 public class ScheduleCreateUpdateRequest {
 
-    @Schema(description = "주 단위 스케줄", example = "[" +
-            "{" +
-            "\"schedule\" : [{\"startTime\": \"2024-01-31T17:00:00+09:00\", \"endTime\": \"2024-01-31T20:30:00+09:00\"}," +
-            "{\"startTime\": \"2024-01-31T21:30:00+09:00\", \"endTime\": \"2024-01-31T22:30:00+09:00\"}]" +
-            "}," +
-            "{" +
-            "\"schedule\" : [{\"startTime\": \"2024-02-1T10:30:00+09:00\", \"endTime\":\"2024-02-1T11:30:00+09:00\" }]" +
-            "}," +
-            "{" +
-            "\"schedule\" : [{\"startTime\": \"2024-02-2T10:30:00+09:00\", \"endTime\":\"2024-02-2T11:30:00+09:00\" }]" +
-            "}," +
-            "{\n" +
-            "\"schedule\" : [{\"startTime\": \"2024-02-3T10:30:00+09:00\", \"endTime\":\"2024-02-3T11:30:00+09:00\" }]" +
-            "}," +
-            "{" +
-            "\"schedule\" : [{\"startTime\": \"2024-02-4T10:30:00+09:00\", \"endTime\":\"2024-02-4T11:30:00+09:00\" }]" +
-            "}" +
-            "]")
+    private Long projectId;
+
+    @Schema(description = "주 단위 스케줄", example =
+            """
+              [
+                {
+                  "schedule": [
+                    {
+                      "startTime": "2024-01-31T17:00:00",
+                      "endTime": "2024-01-31T20:30:00"
+                    },
+                    {
+                      "startTime": "2024-01-31T21:30:00",
+                      "endTime": "2024-01-31T22:30:00"
+                    }
+                  ]
+                },
+                {
+                  "schedule": [
+                    {
+                      "startTime": "2024-02-01T10:30:00",
+                      "endTime": "2024-02-01T11:30:00"
+                    }
+                  ]
+                },
+                {
+                  "schedule": [
+                    {
+                      "startTime": "2024-02-02T10:30:00",
+                      "endTime": "2024-02-02T11:30:00"
+                    }
+                  ]
+                },
+                {
+                  "schedule": [
+                    {
+                      "startTime": "2024-02-03T10:30:00",
+                      "endTime": "2024-02-03T11:30:00"
+                    }
+                  ]
+                },
+                {
+                  "schedule": [
+                    {
+                      "startTime": "2024-02-04T10:30:00",
+                      "endTime": "2024-02-04T11:30:00"
+                    }
+                  ]
+                }
+              ]
+            """)
     private List<ScheduleDayRequest> schedule;
 
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleCreateUpdateRequest.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleCreateUpdateRequest.java
@@ -12,25 +12,22 @@ import java.util.List;
 @Schema(description = "스케줄 생성 및 수정 요청", requiredProperties = {"projectId", "schedule"})
 public class ScheduleCreateUpdateRequest {
 
-    @Schema(description = "프로젝트 식별자", example = "123")
-    private Long projectId;
-
     @Schema(description = "주 단위 스케줄", example = "[" +
             "{" +
-            "\"schedule\" : [{\"startAt\": \"2024-01-31T17:00:00+09:00\", \"endAt\": \"2024-01-31T20:30:00+09:00\"}," +
-            "{\"startAt\": \"2024-01-31T21:30:00+09:00\", \"endAt\": \"2024-01-31T22:30:00+09:00\"}]" +
+            "\"schedule\" : [{\"startTime\": \"2024-01-31T17:00:00+09:00\", \"endTime\": \"2024-01-31T20:30:00+09:00\"}," +
+            "{\"startTime\": \"2024-01-31T21:30:00+09:00\", \"endTime\": \"2024-01-31T22:30:00+09:00\"}]" +
             "}," +
             "{" +
-            "\"schedule\" : [{\"startAt\": \"2024-02-1T10:30:00+09:00\", \"endAt\":\"2024-02-1T11:30:00+09:00\" }]" +
+            "\"schedule\" : [{\"startTime\": \"2024-02-1T10:30:00+09:00\", \"endTime\":\"2024-02-1T11:30:00+09:00\" }]" +
             "}," +
             "{" +
-            "\"schedule\" : [{\"startAt\": \"2024-02-2T10:30:00+09:00\", \"endAt\":\"2024-02-2T11:30:00+09:00\" }]" +
+            "\"schedule\" : [{\"startTime\": \"2024-02-2T10:30:00+09:00\", \"endTime\":\"2024-02-2T11:30:00+09:00\" }]" +
             "}," +
             "{\n" +
-            "\"schedule\" : [{\"startAt\": \"2024-02-3T10:30:00+09:00\", \"endAt\":\"2024-02-3T11:30:00+09:00\" }]" +
+            "\"schedule\" : [{\"startTime\": \"2024-02-3T10:30:00+09:00\", \"endTime\":\"2024-02-3T11:30:00+09:00\" }]" +
             "}," +
             "{" +
-            "\"schedule\" : [{\"startAt\": \"2024-02-4T10:30:00+09:00\", \"endAt\":\"2024-02-4T11:30:00+09:00\" }]" +
+            "\"schedule\" : [{\"startTime\": \"2024-02-4T10:30:00+09:00\", \"endTime\":\"2024-02-4T11:30:00+09:00\" }]" +
             "}" +
             "]")
     private List<ScheduleDayRequest> schedule;

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleDayRequest.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleDayRequest.java
@@ -10,6 +10,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ScheduleDayRequest {
+
     private List<ScheduleDto> schedule;
 
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleDayRequest.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleDayRequest.java
@@ -1,5 +1,7 @@
 package com.appcenter.timepiece.dto.schedule;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,6 +13,10 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ScheduleDayRequest {
 
+    @NotNull @Size(min = 1)
     private List<ScheduleDto> schedule;
 
+    public ScheduleDayRequest(List<ScheduleDto> schedule) {
+        this.schedule = schedule;
+    }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleDayRequest.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleDayRequest.java
@@ -1,7 +1,5 @@
 package com.appcenter.timepiece.dto.schedule;
 
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,7 +11,6 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ScheduleDayRequest {
 
-    @NotNull @Size(min = 1)
     private List<ScheduleDto> schedule;
 
     public ScheduleDayRequest(List<ScheduleDto> schedule) {

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleDayResponse.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleDayResponse.java
@@ -2,6 +2,7 @@ package com.appcenter.timepiece.dto.schedule;
 
 import lombok.Getter;
 
+import java.time.DayOfWeek;
 import java.util.List;
 
 @Getter
@@ -11,8 +12,12 @@ public class ScheduleDayResponse {
 
     private List<ScheduleDto> schedule;
 
-    public ScheduleDayResponse(String daysOfWeek, List<ScheduleDto> schedule) {
+    private ScheduleDayResponse(String daysOfWeek, List<ScheduleDto> schedule) {
         this.daysOfWeek = daysOfWeek;
         this.schedule = schedule;
+    }
+
+    public static ScheduleDayResponse of(DayOfWeek daysOfWeek, List<ScheduleDto> schedule) {
+        return new ScheduleDayResponse(daysOfWeek.name(), schedule);
     }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleDeleteRequest.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleDeleteRequest.java
@@ -21,4 +21,9 @@ public class ScheduleDeleteRequest {
     @Schema(description = "종료일", example = "2024-02-02")
     private LocalDate endDate;
 
+    public ScheduleDeleteRequest(Long projectId, LocalDate startDate, LocalDate endDate) {
+        this.projectId = projectId;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleDeleteRequest.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleDeleteRequest.java
@@ -12,7 +12,7 @@ import java.time.LocalDate;
 @Schema(description = "스케줄 삭제 요청", requiredProperties = {"projectId", "startDate", "endDate"})
 public class ScheduleDeleteRequest {
 
-    @Schema(description = "프로젝트 식별자", example = "123")
+    @Schema(description = "프로젝트 식별자", example = "1")
     private Long projectId;
 
     @Schema(description = "시작일", example = "2024-01-29")

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleDto.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleDto.java
@@ -1,6 +1,7 @@
 package com.appcenter.timepiece.dto.schedule;
 
 import com.appcenter.timepiece.domain.Schedule;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -8,11 +9,13 @@ import java.time.LocalDateTime;
 @Getter
 public class ScheduleDto {
 
+    @NotNull
     private LocalDateTime startTime;
 
+    @NotNull
     private LocalDateTime endTime;
 
-    private ScheduleDto(LocalDateTime startTime, LocalDateTime endTime) {
+    public ScheduleDto(LocalDateTime startTime, LocalDateTime endTime) {
         this.startTime = startTime;
         this.endTime = endTime;
     }

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleDto.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleDto.java
@@ -1,7 +1,6 @@
 package com.appcenter.timepiece.dto.schedule;
 
 import com.appcenter.timepiece.domain.Schedule;
-import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -9,10 +8,8 @@ import java.time.LocalDateTime;
 @Getter
 public class ScheduleDto {
 
-    @NotNull
     private LocalDateTime startTime;
 
-    @NotNull
     private LocalDateTime endTime;
 
     public ScheduleDto(LocalDateTime startTime, LocalDateTime endTime) {

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleDto.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/schedule/ScheduleDto.java
@@ -1,5 +1,6 @@
 package com.appcenter.timepiece.dto.schedule;
 
+import com.appcenter.timepiece.domain.Schedule;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -11,8 +12,12 @@ public class ScheduleDto {
 
     private LocalDateTime endTime;
 
-    public ScheduleDto(LocalDateTime startTime, LocalDateTime endTime) {
+    private ScheduleDto(LocalDateTime startTime, LocalDateTime endTime) {
         this.startTime = startTime;
         this.endTime = endTime;
+    }
+
+    public static ScheduleDto from(Schedule schedule) {
+        return new ScheduleDto(schedule.getStartTime(), schedule.getEndTime());
     }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/repository/MemberProjectRepository.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/repository/MemberProjectRepository.java
@@ -26,6 +26,8 @@ public interface MemberProjectRepository extends JpaRepository<MemberProject, Lo
 
     Optional<MemberProject> findByMemberIdAndProjectId(Long memberId, Long projectId);
 
+    List<MemberProject> findAllByProjectId(Long memberId);
+
     boolean existsByMemberIdAndProjectId(Long memberId, Long projectId);
 
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/repository/ScheduleRepository.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/repository/ScheduleRepository.java
@@ -2,9 +2,28 @@ package com.appcenter.timepiece.repository;
 
 import com.appcenter.timepiece.domain.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("delete from Schedule s " +
+               "where s.memberProject.id = :memberProjectId " +
+               "and s.startTime >= :start " +
+               "and s.endTime <= :end")
+    void deleteMemberSchedulesBetween(Long memberProjectId, LocalDateTime start, LocalDateTime end);
+
+    @Query("select s from Schedule s where s.memberProject.id = :memberProjectId and s.startTime between :start and :end")
+    List<Schedule> findMemberWeekSchedule(Long memberProjectId, LocalDateTime start, LocalDateTime end);
+
+    @Query("select s from Schedule s where s.memberProject.id in :memberProjectId and s.startTime between :start and :end")
+    List<Schedule> findMembersWeekSchedule(List<Long> memberProjectId, LocalDateTime start, LocalDateTime end);
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
@@ -97,7 +97,7 @@ public class ProjectService {
         validateMemberIsInProject(projectId, userDetails);
         return memberProjectRepository.findByProjectIdWithMember(projectId).stream()
                 .map(memberProject -> {
-                    Member member = Objects.requireNonNull(memberProject.getMember());
+                    Member member = requireNonNull(memberProject.getMember()); // NPE!
                     return MemberResponse.of(member, memberProject.getNickname());
                 }).toList();
     }

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ScheduleService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ScheduleService.java
@@ -13,9 +13,6 @@ import com.appcenter.timepiece.repository.ProjectRepository;
 import com.appcenter.timepiece.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springdoc.api.ErrorMessage;
-import org.springframework.cglib.core.Local;
-import org.springframework.scheduling.config.ScheduledTask;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -234,7 +231,6 @@ public class ScheduleService {
         validateIsAppropriatePeriodPerWeek(req, project);
     }
 
-    // todo: LocalDate 간 equals 확인
     private void validateIsIdenticalWeek(ScheduleCreateUpdateRequest req) {
         LocalDate criteria = calculateStartDay(req.getSchedule().get(0).getSchedule().get(0).getStartTime()).toLocalDate();
         for (ScheduleDayRequest scheduleDayRequest : req.getSchedule()) {
@@ -245,7 +241,6 @@ public class ScheduleService {
         }
     }
 
-    // todo: LocalDate끼리 Set에서 contain 검사되는지 확인
     private void validateIsIdenticalDayPerWeek(ScheduleCreateUpdateRequest req) {
         Set<LocalDate> set = new HashSet<>();
         for (ScheduleDayRequest scheduleDayRequest : req.getSchedule()) {
@@ -279,8 +274,6 @@ public class ScheduleService {
         validateIsAppropriateDayOfWeekPerDay(req, project);
     }
 
-    // todo: 하루에 포함된 모든 ScheduleDto가 같은 날짜인지
-    // todo: count = 1확인
     private void validateIsIdenticalDay(ScheduleDayRequest req) {
         if (req.getSchedule().stream()
                     .map(ScheduleDto::getStartTime)

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ScheduleService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ScheduleService.java
@@ -1,0 +1,54 @@
+package com.appcenter.timepiece.service;
+
+import com.appcenter.timepiece.common.exception.ExceptionMessage;
+import com.appcenter.timepiece.common.exception.NotFoundElementException;
+import com.appcenter.timepiece.common.security.CustomUserDetails;
+import com.appcenter.timepiece.domain.MemberProject;
+import com.appcenter.timepiece.domain.Schedule;
+import com.appcenter.timepiece.dto.schedule.ScheduleCreateUpdateRequest;
+import com.appcenter.timepiece.repository.MemberProjectRepository;
+import com.appcenter.timepiece.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ScheduleService {
+
+    private final ScheduleRepository scheduleRepository;
+
+    private final MemberProjectRepository memberProjectRepository;
+
+    @Transactional
+    public void createSchedule(ScheduleCreateUpdateRequest request, Long projectId, UserDetails userDetails) {
+        Long memberId = ((CustomUserDetails) userDetails).getId();
+
+        MemberProject memberProject = memberProjectRepository.findByMemberIdAndProjectId(memberId, projectId)
+                .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.MEMBER_PROJECT_NOT_FOUND));
+
+        List<Schedule> schedulesToSave = request.getSchedule().stream()
+                .flatMap(scheduleDayRequest -> scheduleDayRequest.getSchedule().stream())
+                .map(scheduleDto -> Schedule.of(scheduleDto, memberProject))
+                .collect(Collectors.toList());
+
+        scheduleRepository.saveAll(schedulesToSave);
+    }
+
+    public void editSchedule(ScheduleCreateUpdateRequest request, Long projectId, UserDetails userDetails) {
+        Long memberId = ((CustomUserDetails) userDetails).getId();
+
+    }
+
+    public void deleteSchedule(ScheduleCreateUpdateRequest request, Long projectId, UserDetails userDetails) {
+        Long memberId = ((CustomUserDetails) userDetails).getId();
+
+    }
+
+}

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ScheduleService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ScheduleService.java
@@ -1,11 +1,12 @@
 package com.appcenter.timepiece.service;
 
 import com.appcenter.timepiece.common.exception.ExceptionMessage;
+import com.appcenter.timepiece.common.exception.NotEnoughPrivilegeException;
 import com.appcenter.timepiece.common.exception.NotFoundElementException;
 import com.appcenter.timepiece.common.security.CustomUserDetails;
 import com.appcenter.timepiece.domain.MemberProject;
 import com.appcenter.timepiece.domain.Schedule;
-import com.appcenter.timepiece.dto.schedule.ScheduleCreateUpdateRequest;
+import com.appcenter.timepiece.dto.schedule.*;
 import com.appcenter.timepiece.repository.MemberProjectRepository;
 import com.appcenter.timepiece.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,9 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -26,29 +30,150 @@ public class ScheduleService {
 
     private final MemberProjectRepository memberProjectRepository;
 
+    /**
+     * {@summary 프로젝트 내 모든 멤버의 스케줄을 조회한다(본인포함)}
+     * <p>자신을 포함한 모든 멤버의 스케줄을 조회한다.
+     * 모든 프로젝트 멤버의 스케줄을 전체 조회한 후,스케줄 중 멤버별로 중복되는 요일을 필터링,
+     * 자신의 스케줄을 필터링하여 요일별로 묶어 반환한다. </p>
+     * @param projectId
+     * @param condition
+     * @param userDetails
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public List<ScheduleWeekResponse> findMembersSchedules(Long projectId, LocalDate condition, UserDetails userDetails) {
+        validateMemberIsInProject(projectId, userDetails);
+        List<MemberProject> memberProjects = memberProjectRepository.findAllByProjectId(projectId);
+        LocalDateTime sundayOfWeek = calculateStartDay(LocalDateTime.of(condition, LocalTime.MIN));
+
+        List<Schedule> schedules = scheduleRepository.findMembersWeekSchedule(memberProjects.stream().map(MemberProject::getId).toList(), sundayOfWeek, sundayOfWeek.plusDays(7));
+        return memberProjects.stream().map(memberProject ->
+                new ScheduleWeekResponse(memberProject.getMember().getNickname(),
+                schedules.stream()
+                        .filter(schedule -> schedule.getMemberProject().getId().equals(memberProject.getId()))
+                        .map(schedule -> schedule.getStartTime().getDayOfWeek())
+                        .distinct()
+                        .map(dayOfWeek -> ScheduleDayResponse.of(dayOfWeek,
+                                schedules.stream()
+                                        .filter(schedule -> schedule.getMemberProject().getId().equals(memberProject.getId()))
+                                        .filter(schedule -> schedule
+                                                .getStartTime()
+                                                .getDayOfWeek()
+                                                .equals(dayOfWeek))
+                                        .map(ScheduleDto::from)
+                                        .collect(Collectors.toList())))
+                        .collect(Collectors.toList())))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * {@summary 특정 프로젝트-사용자의 condition 날짜가 포함된 주차 스케줄 조회}
+     * <p>condition이 속한 주차(= 해당 주차의 일요일 ~ 토요일까지)의 사용자 스케줄을 조회한다.
+     * 해당 기간동안의 사용자의 스케줄을 전부 조회한 후 날짜별로 묶어 반환한다.
+     * @param projectId
+     * @param memberId
+     * @param condition
+     * @param userDetails
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public ScheduleWeekResponse findSchedule(Long projectId, Long memberId, LocalDate condition, UserDetails userDetails) {
+        validateMemberIsInProject(projectId, userDetails);
+
+        MemberProject memberProject = memberProjectRepository.findByMemberIdAndProjectId(memberId, projectId)
+                .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.MEMBER_PROJECT_NOT_FOUND));
+        LocalDateTime sundayOfWeek = calculateStartDay(LocalDateTime.of(condition, LocalTime.MIN));
+
+        List<Schedule> schedules = scheduleRepository.findMemberWeekSchedule(memberProject.getId(), sundayOfWeek, sundayOfWeek.plusDays(7));
+        return new ScheduleWeekResponse(memberProject.getMember().getNickname(), schedules.stream()
+                .map(schedule -> schedule.getStartTime().getDayOfWeek())
+                .distinct()
+                .map(dayOfWeek -> ScheduleDayResponse.of(dayOfWeek, schedules.stream()
+                        .filter(schedule -> schedule
+                                .getStartTime()
+                                .getDayOfWeek()
+                                .equals(dayOfWeek))
+                        .map(ScheduleDto::from)
+                        .collect(Collectors.toList())))
+                .collect(Collectors.toList()));
+    }
+
+    // todo: ProjectService와 중복코드
+    private void validateMemberIsInProject(Long projectId, UserDetails userDetails) {
+        Long memberId = ((CustomUserDetails) userDetails).getId();
+        boolean isExist = memberProjectRepository.existsByMemberIdAndProjectId(memberId, projectId);
+        if (!isExist) {
+            throw new NotEnoughPrivilegeException("속하지 않은 프로젝트 정보를 조회할 수 없습니다.");
+        }
+    }
+
+    /**
+     * {@summary 스케줄 생성}
+     * @param request
+     * @param projectId
+     * @param userDetails
+     */
     @Transactional
     public void createSchedule(ScheduleCreateUpdateRequest request, Long projectId, UserDetails userDetails) {
         Long memberId = ((CustomUserDetails) userDetails).getId();
-
         MemberProject memberProject = memberProjectRepository.findByMemberIdAndProjectId(memberId, projectId)
                 .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.MEMBER_PROJECT_NOT_FOUND));
 
         List<Schedule> schedulesToSave = request.getSchedule().stream()
                 .flatMap(scheduleDayRequest -> scheduleDayRequest.getSchedule().stream())
                 .map(scheduleDto -> Schedule.of(scheduleDto, memberProject))
-                .collect(Collectors.toList());
+                .toList();
 
         scheduleRepository.saveAll(schedulesToSave);
     }
 
+    /**
+     * {@summary 기존 스케줄 삭제 후 새 스케줄 저장}
+     * <p>request에 존재하는 첫번째 스케줄의 날짜로, 해당 주차의 첫번째 요일(일요일)을 계산,
+     * 계산한 첫번째 요일 ~ (첫번째 요일 + 7)일의 기간에 속하는 스케줄을 DB에서 삭제하고 request로 받은
+     * 수정 후 스케줄을 저장
+     * @param request
+     * @param projectId
+     * @param userDetails
+     */
     public void editSchedule(ScheduleCreateUpdateRequest request, Long projectId, UserDetails userDetails) {
         Long memberId = ((CustomUserDetails) userDetails).getId();
+        MemberProject memberProject = memberProjectRepository.findByMemberIdAndProjectId(memberId, projectId)
+                .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.MEMBER_PROJECT_NOT_FOUND));
 
+        // todo: IndexOutOfBoundsException!! 발생 가능
+        LocalDateTime sundayOfWeek = calculateStartDay(request.getSchedule().get(0).getSchedule().get(0).getStartTime());
+        scheduleRepository.deleteMemberSchedulesBetween(memberProject.getId(), sundayOfWeek, sundayOfWeek.plusDays(7));
+
+        List<Schedule> schedulesToSave = request.getSchedule().stream()
+                .flatMap(scheduleDayRequest -> scheduleDayRequest.getSchedule().stream())
+                .map(scheduleDto -> Schedule.of(scheduleDto, memberProject))
+                .toList();
+
+        scheduleRepository.saveAll(schedulesToSave);
     }
 
-    public void deleteSchedule(ScheduleCreateUpdateRequest request, Long projectId, UserDetails userDetails) {
-        Long memberId = ((CustomUserDetails) userDetails).getId();
+    // todo: ProjectService와 중복코드
+    private LocalDateTime calculateStartDay(LocalDateTime condition) {
+        return condition.minusDays(condition.getDayOfWeek().getValue() % 7);
+    }
 
+
+    /**
+     * {@summary start <= 날짜 < end에 속하는 스케줄 삭제}
+     * @param request
+     * @param projectId
+     * @param userDetails
+     */
+    public void deleteSchedule(ScheduleDeleteRequest request, Long projectId, UserDetails userDetails) {
+        Long memberId = ((CustomUserDetails) userDetails).getId();
+        MemberProject memberProject = memberProjectRepository.findByMemberIdAndProjectId(memberId, projectId)
+                .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.MEMBER_PROJECT_NOT_FOUND));
+
+        // todo: 현재 endDate 날짜에 속하는 스케줄은 삭제되지 않음
+        scheduleRepository.deleteMemberSchedulesBetween(memberProject.getId(),
+                LocalDateTime.of(request.getStartDate(), LocalTime.MIN),
+                LocalDateTime.of(request.getEndDate(), LocalTime.MIN));
     }
 
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ScheduleService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ScheduleService.java
@@ -291,12 +291,12 @@ public class ScheduleService {
 
     private void validateDuplicateSchedulePerDay(ScheduleDayRequest req) {
         req.getSchedule().sort(Comparator.comparing(ScheduleDto::getStartTime));
-        LocalDateTime before = LocalDateTime.of(LocalDate.now(), LocalTime.MIN);
+        LocalTime before = LocalTime.MIN;
         for (ScheduleDto scheduleDto : req.getSchedule()) {
-            if (before.isAfter(scheduleDto.getStartTime())) {
-                throw new IllegalArgumentException("");
+            if (before.isAfter(scheduleDto.getStartTime().toLocalTime())) {
+                throw new IllegalArgumentException(ExceptionMessage.INTERSECT_TIME.getMessage());
             }
-            before = scheduleDto.getEndTime();
+            before = scheduleDto.getEndTime().toLocalTime();
         }
     }
 

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ScheduleService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ScheduleService.java
@@ -5,21 +5,28 @@ import com.appcenter.timepiece.common.exception.NotEnoughPrivilegeException;
 import com.appcenter.timepiece.common.exception.NotFoundElementException;
 import com.appcenter.timepiece.common.security.CustomUserDetails;
 import com.appcenter.timepiece.domain.MemberProject;
+import com.appcenter.timepiece.domain.Project;
 import com.appcenter.timepiece.domain.Schedule;
 import com.appcenter.timepiece.dto.schedule.*;
 import com.appcenter.timepiece.repository.MemberProjectRepository;
+import com.appcenter.timepiece.repository.ProjectRepository;
 import com.appcenter.timepiece.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.api.ErrorMessage;
+import org.springframework.cglib.core.Local;
+import org.springframework.scheduling.config.ScheduledTask;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
+
 
 @Service
 @Slf4j
@@ -27,14 +34,15 @@ import java.util.stream.Collectors;
 public class ScheduleService {
 
     private final ScheduleRepository scheduleRepository;
-
     private final MemberProjectRepository memberProjectRepository;
+    private final ProjectRepository projectRepository;
 
     /**
      * {@summary 프로젝트 내 모든 멤버의 스케줄을 조회한다(본인포함)}
      * <p>자신을 포함한 모든 멤버의 스케줄을 조회한다.
      * 모든 프로젝트 멤버의 스케줄을 전체 조회한 후,스케줄 중 멤버별로 중복되는 요일을 필터링,
      * 자신의 스케줄을 필터링하여 요일별로 묶어 반환한다. </p>
+     *
      * @param projectId
      * @param condition
      * @param userDetails
@@ -48,21 +56,21 @@ public class ScheduleService {
 
         List<Schedule> schedules = scheduleRepository.findMembersWeekSchedule(memberProjects.stream().map(MemberProject::getId).toList(), sundayOfWeek, sundayOfWeek.plusDays(7));
         return memberProjects.stream().map(memberProject ->
-                new ScheduleWeekResponse(memberProject.getMember().getNickname(),
-                schedules.stream()
-                        .filter(schedule -> schedule.getMemberProject().getId().equals(memberProject.getId()))
-                        .map(schedule -> schedule.getStartTime().getDayOfWeek())
-                        .distinct()
-                        .map(dayOfWeek -> ScheduleDayResponse.of(dayOfWeek,
+                        new ScheduleWeekResponse(memberProject.getMember().getNickname(),
                                 schedules.stream()
                                         .filter(schedule -> schedule.getMemberProject().getId().equals(memberProject.getId()))
-                                        .filter(schedule -> schedule
-                                                .getStartTime()
-                                                .getDayOfWeek()
-                                                .equals(dayOfWeek))
-                                        .map(ScheduleDto::from)
+                                        .map(schedule -> schedule.getStartTime().getDayOfWeek())
+                                        .distinct()
+                                        .map(dayOfWeek -> ScheduleDayResponse.of(dayOfWeek,
+                                                schedules.stream()
+                                                        .filter(schedule -> schedule.getMemberProject().getId().equals(memberProject.getId()))
+                                                        .filter(schedule -> schedule
+                                                                .getStartTime()
+                                                                .getDayOfWeek()
+                                                                .equals(dayOfWeek))
+                                                        .map(ScheduleDto::from)
+                                                        .collect(Collectors.toList())))
                                         .collect(Collectors.toList())))
-                        .collect(Collectors.toList())))
                 .collect(Collectors.toList());
     }
 
@@ -70,6 +78,7 @@ public class ScheduleService {
      * {@summary 특정 프로젝트-사용자의 condition 날짜가 포함된 주차 스케줄 조회}
      * <p>condition이 속한 주차(= 해당 주차의 일요일 ~ 토요일까지)의 사용자 스케줄을 조회한다.
      * 해당 기간동안의 사용자의 스케줄을 전부 조회한 후 날짜별로 묶어 반환한다.
+     *
      * @param projectId
      * @param memberId
      * @param condition
@@ -109,12 +118,17 @@ public class ScheduleService {
 
     /**
      * {@summary 스케줄 생성}
+     *
      * @param request
      * @param projectId
      * @param userDetails
      */
     @Transactional
     public void createSchedule(ScheduleCreateUpdateRequest request, Long projectId, UserDetails userDetails) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.PROJECT_NOT_FOUND));
+        validateScheduleCreateUpdateRequest(request, project);
+
         Long memberId = ((CustomUserDetails) userDetails).getId();
         MemberProject memberProject = memberProjectRepository.findByMemberIdAndProjectId(memberId, projectId)
                 .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.MEMBER_PROJECT_NOT_FOUND));
@@ -132,16 +146,21 @@ public class ScheduleService {
      * <p>request에 존재하는 첫번째 스케줄의 날짜로, 해당 주차의 첫번째 요일(일요일)을 계산,
      * 계산한 첫번째 요일 ~ (첫번째 요일 + 7)일의 기간에 속하는 스케줄을 DB에서 삭제하고 request로 받은
      * 수정 후 스케줄을 저장
+     *
      * @param request
      * @param projectId
      * @param userDetails
      */
     public void editSchedule(ScheduleCreateUpdateRequest request, Long projectId, UserDetails userDetails) {
+        Project project = projectRepository.findById(projectId)
+                        .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.PROJECT_NOT_FOUND));
+        validateScheduleCreateUpdateRequest(request, project);
+
         Long memberId = ((CustomUserDetails) userDetails).getId();
         MemberProject memberProject = memberProjectRepository.findByMemberIdAndProjectId(memberId, projectId)
                 .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.MEMBER_PROJECT_NOT_FOUND));
 
-        // todo: IndexOutOfBoundsException!! 발생 가능
+        // todo: IndexOutOfBoundsException!! 발생 가능 -> Not Null, Not Empty하면 될 듯?
         LocalDateTime sundayOfWeek = calculateStartDay(request.getSchedule().get(0).getSchedule().get(0).getStartTime());
         scheduleRepository.deleteMemberSchedulesBetween(memberProject.getId(), sundayOfWeek, sundayOfWeek.plusDays(7));
 
@@ -153,14 +172,14 @@ public class ScheduleService {
         scheduleRepository.saveAll(schedulesToSave);
     }
 
-    // todo: ProjectService와 중복코드
     private LocalDateTime calculateStartDay(LocalDateTime condition) {
         return condition.minusDays(condition.getDayOfWeek().getValue() % 7);
     }
 
 
     /**
-     * {@summary start <= 날짜 < end에 속하는 스케줄 삭제}
+     * {@summary start <= 날짜 < end}에 속하는 스케줄 삭제
+     *
      * @param request
      * @param projectId
      * @param userDetails
@@ -170,10 +189,174 @@ public class ScheduleService {
         MemberProject memberProject = memberProjectRepository.findByMemberIdAndProjectId(memberId, projectId)
                 .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.MEMBER_PROJECT_NOT_FOUND));
 
-        // todo: 현재 endDate 날짜에 속하는 스케줄은 삭제되지 않음
         scheduleRepository.deleteMemberSchedulesBetween(memberProject.getId(),
                 LocalDateTime.of(request.getStartDate(), LocalTime.MIN),
                 LocalDateTime.of(request.getEndDate(), LocalTime.MIN));
     }
 
+    /**
+     * ScheduleCreateUpdateRequest에 대한 모든 유효성 검사를 위임하는 메서드<br>
+     * Week, Day 범위로 검증을 위임한다.
+     * @param req ScheduleCreateUpdateRequest
+     * @param project Project
+     */
+    private void validateScheduleCreateUpdateRequest(ScheduleCreateUpdateRequest req, Project project) {
+        validateScheduleWeekRequest(req, project);
+        for (ScheduleDayRequest scheduleDayRequest : req.getSchedule()) {
+            validateDayAndLowLevelRequest(scheduleDayRequest, project);
+        }
+    }
+
+    /**
+     * ScheduleCreateUpdateRequest를 일(Day) 단위 및 ScheduleDto 단위 검증으로 위임한다.
+     * @param req ScheduleDayRequest
+     * @param project Project
+     */
+    private void validateDayAndLowLevelRequest(ScheduleDayRequest req, Project project) {
+        validateScheduleDayRequest(req, project);
+        for (ScheduleDto scheduleDto : req.getSchedule()) {
+            validateScheduleDto(scheduleDto, project);
+        }
+    }
+
+    /**
+     * ScheduleCreateUpdateRequest Week 단위 검증 <br>
+     * 수행목록 <br>
+     * 1. validateIsIdenticalWeek - 일주일(일-토요일) 단위의 요청이 맞는지 검사 <br>
+     * 2. validateIsIdenticalDayPerWeek - 중복된 날짜의 요청이 있는지 검사 <br>
+     * 3. validateIsAppropriatePeriodPerWeek - (생성 시 정했던)프로젝트 기간 내인지 검사
+     * @param req ScheduleCreateUpdateRequest
+     * @param project Project
+     */
+    private void validateScheduleWeekRequest(ScheduleCreateUpdateRequest req, Project project) {
+        validateIsIdenticalWeek(req);
+        validateIsIdenticalDayPerWeek(req);
+        validateIsAppropriatePeriodPerWeek(req, project);
+    }
+
+    // todo: LocalDate 간 equals 확인
+    private void validateIsIdenticalWeek(ScheduleCreateUpdateRequest req) {
+        LocalDate criteria = calculateStartDay(req.getSchedule().get(0).getSchedule().get(0).getStartTime()).toLocalDate();
+        for (ScheduleDayRequest scheduleDayRequest : req.getSchedule()) {
+            LocalDateTime validTarget = calculateStartDay(scheduleDayRequest.getSchedule().get(0).getStartTime());
+            if (!Objects.equals(criteria, validTarget.toLocalDate())) {
+                throw new IllegalArgumentException(ExceptionMessage.INVALID_WEEK.getMessage());
+            }
+        }
+    }
+
+    // todo: LocalDate끼리 Set에서 contain 검사되는지 확인
+    private void validateIsIdenticalDayPerWeek(ScheduleCreateUpdateRequest req) {
+        Set<LocalDate> set = new HashSet<>();
+        for (ScheduleDayRequest scheduleDayRequest : req.getSchedule()) {
+            if (set.contains(scheduleDayRequest.getSchedule().get(0).getStartTime().toLocalDate())) {
+                throw new IllegalArgumentException(ExceptionMessage.DUPLICATE_DATE.getMessage());
+            }
+            set.add(req.getSchedule().get(0).getSchedule().get(0).getStartTime().toLocalDate());
+        }
+    }
+
+    private void validateIsAppropriatePeriodPerWeek(ScheduleCreateUpdateRequest req, Project project) {
+        LocalDate criteria = calculateStartDay(req.getSchedule().get(0).getSchedule().get(0).getStartTime()).toLocalDate();
+        if (criteria.isBefore(project.getStartDate()) || criteria.plusDays(6).isAfter(project.getEndDate())) {
+            throw new IllegalArgumentException(ExceptionMessage.INVALID_PROJECT_PERIOD.getMessage());
+        }
+    }
+
+
+    /**
+     * ScheduleCreateUpdateRequest 일(Day) 단위 검증 <br>
+     * 수행목록 <br>
+     * 1. validateIsIdenticalDay - 모든 ScheduleDto의 동일한 날짜인지 검사<br>
+     * 2. validateDuplicateSchedulePerDay - ScheduleDto 간 요청 시간이 중복/교차되는지 검사<br>
+     * 3. validateIsAppropriateDayOfWeekPerDay - (생성 시 정했던)프로젝트 요일인지 검사
+     * @param req ScheduleDayRequest
+     * @param project Project
+     */
+    private void validateScheduleDayRequest(ScheduleDayRequest req, Project project) {
+        validateIsIdenticalDay(req);
+        validateDuplicateSchedulePerDay(req);
+        validateIsAppropriateDayOfWeekPerDay(req, project);
+    }
+
+    // todo: 하루에 포함된 모든 ScheduleDto가 같은 날짜인지
+    // todo: count = 1확인
+    private void validateIsIdenticalDay(ScheduleDayRequest req) {
+        if (req.getSchedule().stream()
+                    .map(ScheduleDto::getStartTime)
+                    .map(LocalDateTime::toLocalDate).distinct().count() != 1L) {
+            throw new IllegalArgumentException(ExceptionMessage.INVALID_DATE.getMessage());
+        }
+    }
+
+    private void validateDuplicateSchedulePerDay(ScheduleDayRequest req) {
+        req.getSchedule().sort(Comparator.comparing(ScheduleDto::getStartTime));
+        LocalDateTime before = LocalDateTime.of(LocalDate.now(), LocalTime.MIN);
+        for (ScheduleDto scheduleDto : req.getSchedule()) {
+            if (before.isAfter(scheduleDto.getStartTime())) {
+                throw new IllegalArgumentException("");
+            }
+            before = scheduleDto.getEndTime();
+        }
+    }
+
+    private void validateIsAppropriateDayOfWeekPerDay(ScheduleDayRequest req, Project project) {
+        Set<DayOfWeek> dayOfWeeks = project.getDaysOfWeek();
+        DayOfWeek day= req.getSchedule().get(0).getStartTime().getDayOfWeek();
+        if (!dayOfWeeks.contains(day)) {
+            throw new IllegalArgumentException(ExceptionMessage.INVALID_PROJECT_DAY_OF_WEEK.getMessage());
+        }
+    }
+
+
+
+    /**
+     * ScheduleCreateUpdateRequest ScheduleDto 단위 검증 <br>
+     * 수행목록 <br>
+     * 1. validateIsMultipleOfHalfHourPerSchedule - startTime, endTime이 30분 단위인지 검사 <br>
+     * 2. validateTimeSequencePerSchedule - startTime < endTime을 만족하는지 검사 <br>
+     * 3. validateIsSameDayPerSchedule - startDate == endDate를 만족하는지 검사 <br>
+     * 4. validateIsAppropriateTimePerSchedule - (생성 시 정했던)프로젝트 시간 내인지 검사
+     * @param req ScheduleDto
+     * @param project Project
+     */
+    private void validateScheduleDto(ScheduleDto req, Project project) {
+        LocalDateTime startDateTime = req.getStartTime();
+        LocalDateTime endDateTime = req.getEndTime();
+
+        LocalDate startDate = startDateTime.toLocalDate();
+        LocalDate endDate = endDateTime.toLocalDate();
+
+        LocalTime startTime = startDateTime.toLocalTime();
+        LocalTime endTime = endDateTime.toLocalTime();
+
+        validateIsMultipleOfHalfHourPerSchedule(startTime, endTime);
+        validateTimeSequencePerSchedule(startTime, endTime);
+        validateIsSameDayPerSchedule(startDate, endDate);
+        validateIsAppropriateTimePerSchedule(startTime, endTime, project);
+    }
+
+    private void validateIsMultipleOfHalfHourPerSchedule(LocalTime startTime, LocalTime endTime) {
+        if ((startTime.getMinute() % 30 != 0) || (endTime.getMinute() % 30 != 0)) {
+            throw new IllegalArgumentException(ExceptionMessage.INVALID_TIME_UNIT.getMessage());
+        }
+    }
+
+    private void validateTimeSequencePerSchedule(LocalTime startTime, LocalTime endTime) {
+        if (startTime.isAfter(endTime)) {
+            throw new IllegalArgumentException(ExceptionMessage.INVALID_TIME_SEQUENCE.getMessage());
+        }
+    }
+
+    private void validateIsSameDayPerSchedule(LocalDate startDate, LocalDate endDate) {
+        if (!Objects.equals(startDate, endDate)) {
+            throw new IllegalArgumentException(ExceptionMessage.IS_NOT_SAME_DAY.getMessage());
+        }
+    }
+
+    private void validateIsAppropriateTimePerSchedule(LocalTime startTime, LocalTime endTime, Project project) {
+        if (startTime.isBefore(project.getStartTime()) || endTime.isAfter(project.getEndTime())) {
+            throw new IllegalArgumentException(ExceptionMessage.INVALID_PROJECT_TIME.getMessage());
+        }
+    }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ScheduleService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ScheduleService.java
@@ -112,7 +112,7 @@ public class ScheduleService {
         Long memberId = ((CustomUserDetails) userDetails).getId();
         boolean isExist = memberProjectRepository.existsByMemberIdAndProjectId(memberId, projectId);
         if (!isExist) {
-            throw new NotEnoughPrivilegeException("속하지 않은 프로젝트 정보를 조회할 수 없습니다.");
+            throw new NotEnoughPrivilegeException(ExceptionMessage.NOT_MEMBER);
         }
     }
 

--- a/timepiece/src/test/java/com/appcenter/timepiece/service/ScheduleServiceTest.java
+++ b/timepiece/src/test/java/com/appcenter/timepiece/service/ScheduleServiceTest.java
@@ -72,7 +72,7 @@ class ScheduleServiceTest {
         ScheduleDayRequest scheduleDayRequest4 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto5)));
 
         ScheduleCreateUpdateRequest scheduleCreateUpdateRequest =
-                new ScheduleCreateUpdateRequest(1L, List.of(scheduleDayRequest1, scheduleDayRequest2, scheduleDayRequest3, scheduleDayRequest4));
+                new ScheduleCreateUpdateRequest(List.of(scheduleDayRequest1, scheduleDayRequest2, scheduleDayRequest3, scheduleDayRequest4));
         Member member = new Member(null, "namu", "namu2024@gmail.com", "", "", List.of("ROLE_USER"));
         Project project = Project.builder()
                 .title("test").description("설명")
@@ -120,7 +120,7 @@ class ScheduleServiceTest {
         ScheduleDayRequest scheduleDayRequest4 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto5)));
 
         ScheduleCreateUpdateRequest scheduleCreateUpdateRequest =
-                new ScheduleCreateUpdateRequest(1L, List.of(scheduleDayRequest1, scheduleDayRequest2, scheduleDayRequest3, scheduleDayRequest4));
+                new ScheduleCreateUpdateRequest(List.of(scheduleDayRequest1, scheduleDayRequest2, scheduleDayRequest3, scheduleDayRequest4));
         Member member = new Member(null, "namu", "namu2024@gmail.com", "", "", List.of("ROLE_USER"));
         Project project = Project.builder()
                 .title("test").description("설명")
@@ -164,7 +164,7 @@ class ScheduleServiceTest {
         ScheduleDayRequest scheduleDayRequest4 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto4, scheduleDto5)));
 
         ScheduleCreateUpdateRequest scheduleCreateUpdateRequest =
-                new ScheduleCreateUpdateRequest(1L, List.of(scheduleDayRequest1, scheduleDayRequest2, scheduleDayRequest3, scheduleDayRequest4));
+                new ScheduleCreateUpdateRequest(List.of(scheduleDayRequest1, scheduleDayRequest2, scheduleDayRequest3, scheduleDayRequest4));
         Member member = new Member(null, "namu", "namu2024@gmail.com", "", "", List.of("ROLE_USER"));
         Project project = Project.builder()
                 .title("test").description("설명")
@@ -208,7 +208,7 @@ class ScheduleServiceTest {
         ScheduleDayRequest scheduleDayRequest4 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto5)));
 
         ScheduleCreateUpdateRequest scheduleCreateUpdateRequest =
-                new ScheduleCreateUpdateRequest(1L, List.of(scheduleDayRequest1, scheduleDayRequest2, scheduleDayRequest3, scheduleDayRequest4));
+                new ScheduleCreateUpdateRequest(List.of(scheduleDayRequest1, scheduleDayRequest2, scheduleDayRequest3, scheduleDayRequest4));
         Member member = new Member(null, "namu", "namu2024@gmail.com", "", "", List.of("ROLE_USER"));
         Project project = Project.builder()
                 .title("test").description("설명")
@@ -248,7 +248,7 @@ class ScheduleServiceTest {
                 new ArrayList<>(List.of(scheduleDto1, scheduleDto2, scheduleDto3)));
 
         ScheduleCreateUpdateRequest scheduleCreateUpdateRequest =
-                new ScheduleCreateUpdateRequest(1L, List.of(scheduleDayRequest1));
+                new ScheduleCreateUpdateRequest(List.of(scheduleDayRequest1));
         Member member =
                 new Member(null, "namu", "namu2024@gmail.com", "", "", List.of("ROLE_USER"));
         Project project = Project.builder()
@@ -284,7 +284,7 @@ class ScheduleServiceTest {
         ScheduleDayRequest scheduleDayRequest1 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto1, scheduleDto2, scheduleDto3)));
 
         ScheduleCreateUpdateRequest scheduleCreateUpdateRequest =
-                new ScheduleCreateUpdateRequest(1L, List.of(scheduleDayRequest1));
+                new ScheduleCreateUpdateRequest(List.of(scheduleDayRequest1));
         Member member = new Member(null, "namu", "namu2024@gmail.com", "", "", List.of("ROLE_USER"));
         Project project = Project.builder()
                 .title("test").description("설명")
@@ -319,7 +319,7 @@ class ScheduleServiceTest {
 
 
         ScheduleCreateUpdateRequest scheduleCreateUpdateRequest =
-                new ScheduleCreateUpdateRequest(1L, List.of(scheduleDayRequest1));
+                new ScheduleCreateUpdateRequest(List.of(scheduleDayRequest1));
         Member member = new Member(null, "namu", "namu2024@gmail.com", "", "", List.of("ROLE_USER"));
         Project project = Project.builder()
                 .title("test").description("설명")
@@ -353,7 +353,7 @@ class ScheduleServiceTest {
         ScheduleDayRequest scheduleDayRequest1 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto1, scheduleDto2, scheduleDto3)));
 
         ScheduleCreateUpdateRequest scheduleCreateUpdateRequest =
-                new ScheduleCreateUpdateRequest(1L, List.of(scheduleDayRequest1));
+                new ScheduleCreateUpdateRequest(List.of(scheduleDayRequest1));
         Member member = new Member(null, "namu", "namu2024@gmail.com", "", "", List.of("ROLE_USER"));
         Project project = Project.builder()
                 .title("test").description("설명")
@@ -387,7 +387,7 @@ class ScheduleServiceTest {
         ScheduleDayRequest scheduleDayRequest1 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto1, scheduleDto2, scheduleDto3)));
 
         ScheduleCreateUpdateRequest scheduleCreateUpdateRequest =
-                new ScheduleCreateUpdateRequest(1L, List.of(scheduleDayRequest1));
+                new ScheduleCreateUpdateRequest(List.of(scheduleDayRequest1));
         Member member = new Member(null, "namu", "namu2024@gmail.com", "", "", List.of("ROLE_USER"));
         Project project = Project.builder()
                 .title("test").description("설명")

--- a/timepiece/src/test/java/com/appcenter/timepiece/service/ScheduleServiceTest.java
+++ b/timepiece/src/test/java/com/appcenter/timepiece/service/ScheduleServiceTest.java
@@ -1,0 +1,407 @@
+package com.appcenter.timepiece.service;
+
+import com.appcenter.timepiece.common.exception.ExceptionMessage;
+import com.appcenter.timepiece.common.security.CustomUserDetails;
+import com.appcenter.timepiece.domain.Member;
+import com.appcenter.timepiece.domain.MemberProject;
+import com.appcenter.timepiece.domain.Project;
+import com.appcenter.timepiece.dto.schedule.ScheduleCreateUpdateRequest;
+import com.appcenter.timepiece.dto.schedule.ScheduleDayRequest;
+import com.appcenter.timepiece.dto.schedule.ScheduleDto;
+import com.appcenter.timepiece.repository.MemberProjectRepository;
+import com.appcenter.timepiece.repository.ProjectRepository;
+import com.appcenter.timepiece.repository.ScheduleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class ScheduleServiceTest {
+
+    @InjectMocks
+    private ScheduleService scheduleService;
+
+    @Mock
+    private ScheduleRepository scheduleRepository;
+
+    @Mock
+    private MemberProjectRepository memberProjectRepository;
+
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @DisplayName("ScheduleCreateUpdateRequest가 일주일 분량의 요청이 맞는지 검증한다.")
+    @Test
+    void validateIsIdenticalWeek() {
+
+        ScheduleDto scheduleDto1 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 19, 9, 30),
+                LocalDateTime.of(2024, 4, 19, 10, 30));
+        ScheduleDto scheduleDto2 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 19, 8, 30),
+                LocalDateTime.of(2024, 4, 19, 9, 0));
+        ScheduleDto scheduleDto3 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 20, 19, 30),
+                LocalDateTime.of(2024, 4, 20, 21, 30));
+        ScheduleDto scheduleDto4 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 17, 9, 30),
+                LocalDateTime.of(2024, 4, 17, 10, 30));
+        ScheduleDto scheduleDto5 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 21, 9, 30),
+                LocalDateTime.of(2024, 4, 21, 10, 30));
+
+        ScheduleDayRequest scheduleDayRequest1 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto1, scheduleDto2)));
+        ScheduleDayRequest scheduleDayRequest2 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto3)));
+        ScheduleDayRequest scheduleDayRequest3 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto4)));
+        ScheduleDayRequest scheduleDayRequest4 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto5)));
+
+        ScheduleCreateUpdateRequest scheduleCreateUpdateRequest =
+                new ScheduleCreateUpdateRequest(1L, List.of(scheduleDayRequest1, scheduleDayRequest2, scheduleDayRequest3, scheduleDayRequest4));
+        Member member = new Member(null, "namu", "namu2024@gmail.com", "", "", List.of("ROLE_USER"));
+        Project project = Project.builder()
+                .title("test").description("설명")
+                .startDate(LocalDate.of(2020, 1, 1))
+                .endDate(LocalDate.of(2025, 1, 1))
+                .startTime(LocalTime.MIN).endTime(LocalTime.MAX)
+                .daysOfWeek(Arrays.stream(DayOfWeek.values()).collect(Collectors.toSet()))
+                .memberProjects(new ArrayList<>()).invitations(new ArrayList<>())
+                .cover(null).color("FFFFFF")
+                .build();
+        MemberProject memberProject = MemberProject.of(member, project);
+
+        Mockito.when(projectRepository.findById(1L))
+                .thenReturn(Optional.of(project));
+//        Mockito.when(memberProjectRepository.findByMemberIdAndProjectId(1L, 1L))
+//                        .thenReturn(Optional.of(memberProject));
+
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> scheduleService.createSchedule(scheduleCreateUpdateRequest, 1L, CustomUserDetails.from(member)));
+        assertEquals(ExceptionMessage.INVALID_WEEK.getMessage(), exception.getMessage());
+    }
+
+    @DisplayName("ScheduleCreateUpdateRequest의 ScheduleDayRequest 간 중복된 날짜가 없는지 검증한다.")
+    @Test
+    void validateIsIdenticalDayPerWeek() {
+
+        ScheduleDto scheduleDto1 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 19, 9, 30),
+                LocalDateTime.of(2024, 4, 19, 10, 30));
+        ScheduleDto scheduleDto2 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 19, 8, 30),
+                LocalDateTime.of(2024, 4, 19, 9, 0));
+        ScheduleDto scheduleDto3 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 20, 19, 30),
+                LocalDateTime.of(2024, 4, 20, 21, 30));
+        ScheduleDto scheduleDto4 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 17, 9, 30),
+                LocalDateTime.of(2024, 4, 17, 10, 30));
+        ScheduleDto scheduleDto5 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 19, 19, 30),
+                LocalDateTime.of(2024, 4, 19, 20, 30));
+
+        ScheduleDayRequest scheduleDayRequest1 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto1, scheduleDto2)));
+        ScheduleDayRequest scheduleDayRequest2 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto3)));
+        ScheduleDayRequest scheduleDayRequest3 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto4)));
+        ScheduleDayRequest scheduleDayRequest4 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto5)));
+
+        ScheduleCreateUpdateRequest scheduleCreateUpdateRequest =
+                new ScheduleCreateUpdateRequest(1L, List.of(scheduleDayRequest1, scheduleDayRequest2, scheduleDayRequest3, scheduleDayRequest4));
+        Member member = new Member(null, "namu", "namu2024@gmail.com", "", "", List.of("ROLE_USER"));
+        Project project = Project.builder()
+                .title("test").description("설명")
+                .startDate(LocalDate.of(2020, 1, 1))
+                .endDate(LocalDate.of(2025, 1, 1))
+                .startTime(LocalTime.MIN).endTime(LocalTime.MAX)
+                .daysOfWeek(Arrays.stream(DayOfWeek.values()).collect(Collectors.toSet()))
+                .memberProjects(new ArrayList<>()).invitations(new ArrayList<>())
+                .cover(null).color("FFFFFF")
+                .build();
+
+        Mockito.when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
+
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> scheduleService.createSchedule(scheduleCreateUpdateRequest, 1L, CustomUserDetails.from(member)));
+        assertEquals(ExceptionMessage.DUPLICATE_DATE.getMessage(), exception.getMessage());
+    }
+
+    @DisplayName("ScheduleCreateUpdateRequest가 프로젝트 기간 이내인지 검증한다.")
+    @Test
+    void validateIsAppropriatePeriodPerWeek() {
+
+        ScheduleDto scheduleDto1 = new ScheduleDto(
+                LocalDateTime.of(2025, 4, 16, 19, 30),
+                LocalDateTime.of(2025, 4, 16, 20, 30));
+        ScheduleDto scheduleDto2 = new ScheduleDto(
+                LocalDateTime.of(2025, 4, 17, 9, 30),
+                LocalDateTime.of(2025, 4, 17, 10, 30));
+        ScheduleDto scheduleDto3 = new ScheduleDto(
+                LocalDateTime.of(2025, 4, 18, 19, 30),
+                LocalDateTime.of(2025, 4, 18, 21, 30));
+        ScheduleDto scheduleDto4 = new ScheduleDto(
+                LocalDateTime.of(2025, 4, 19, 8, 30),
+                LocalDateTime.of(2025, 4, 19, 9, 0));
+        ScheduleDto scheduleDto5 = new ScheduleDto(
+                LocalDateTime.of(2025, 4, 19, 9, 30),
+                LocalDateTime.of(2025, 4, 19, 10, 30));
+
+        ScheduleDayRequest scheduleDayRequest1 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto1)));
+        ScheduleDayRequest scheduleDayRequest2 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto2)));
+        ScheduleDayRequest scheduleDayRequest3 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto3)));
+        ScheduleDayRequest scheduleDayRequest4 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto4, scheduleDto5)));
+
+        ScheduleCreateUpdateRequest scheduleCreateUpdateRequest =
+                new ScheduleCreateUpdateRequest(1L, List.of(scheduleDayRequest1, scheduleDayRequest2, scheduleDayRequest3, scheduleDayRequest4));
+        Member member = new Member(null, "namu", "namu2024@gmail.com", "", "", List.of("ROLE_USER"));
+        Project project = Project.builder()
+                .title("test").description("설명")
+                .startDate(LocalDate.of(2020, 1, 1))
+                .endDate(LocalDate.of(2025, 1, 1))
+                .startTime(LocalTime.MIN).endTime(LocalTime.MAX)
+                .daysOfWeek(Arrays.stream(DayOfWeek.values()).collect(Collectors.toSet()))
+                .memberProjects(new ArrayList<>()).invitations(new ArrayList<>())
+                .cover(null).color("FFFFFF")
+                .build();
+
+        Mockito.when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
+
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> scheduleService.createSchedule(scheduleCreateUpdateRequest, 1L, CustomUserDetails.from(member)));
+        assertEquals(ExceptionMessage.INVALID_PROJECT_PERIOD.getMessage(), exception.getMessage());
+    }
+
+    @DisplayName("ScheduleDayRequest의 모든 ScheduleDto 날짜가 동일한지 검증한다.")
+    @Test
+    void validateIsIdenticalDay() {
+
+        ScheduleDto scheduleDto1 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 19, 9, 30),
+                LocalDateTime.of(2024, 4, 19, 10, 30));
+        ScheduleDto scheduleDto2 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 18, 8, 30),
+                LocalDateTime.of(2024, 4, 18, 9, 0));
+        ScheduleDto scheduleDto3 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 16, 19, 30),
+                LocalDateTime.of(2024, 4, 16, 20, 30));
+        ScheduleDto scheduleDto4 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 17, 9, 30),
+                LocalDateTime.of(2024, 4, 17, 10, 30));
+        ScheduleDto scheduleDto5 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 20, 19, 30),
+                LocalDateTime.of(2024, 4, 20, 21, 30));
+
+        ScheduleDayRequest scheduleDayRequest1 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto1, scheduleDto2)));
+        ScheduleDayRequest scheduleDayRequest2 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto3)));
+        ScheduleDayRequest scheduleDayRequest3 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto4)));
+        ScheduleDayRequest scheduleDayRequest4 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto5)));
+
+        ScheduleCreateUpdateRequest scheduleCreateUpdateRequest =
+                new ScheduleCreateUpdateRequest(1L, List.of(scheduleDayRequest1, scheduleDayRequest2, scheduleDayRequest3, scheduleDayRequest4));
+        Member member = new Member(null, "namu", "namu2024@gmail.com", "", "", List.of("ROLE_USER"));
+        Project project = Project.builder()
+                .title("test").description("설명")
+                .startDate(LocalDate.of(2020, 1, 1))
+                .endDate(LocalDate.of(2025, 1, 1))
+                .startTime(LocalTime.MIN).endTime(LocalTime.MAX)
+                .daysOfWeek(Arrays.stream(DayOfWeek.values()).collect(Collectors.toSet()))
+                .memberProjects(new ArrayList<>()).invitations(new ArrayList<>())
+                .cover(null).color("FFFFFF")
+                .build();
+
+        Mockito.when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
+
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> scheduleService.createSchedule(scheduleCreateUpdateRequest, 1L, CustomUserDetails.from(member)));
+        assertEquals(ExceptionMessage.INVALID_DATE.getMessage(), exception.getMessage());
+    }
+
+    @DisplayName("ScheduleDayRequest가 프로젝트 수행 요일인지 검증한다.")
+    @Test
+    void validateIsAppropriateDayOfWeekPerDay() {
+    }
+
+    @DisplayName("ScheduleDayRequest의 ScheduleDto 간 시간 중복/교차가 없는지 검증한다.")
+    @Test
+    void validateDuplicateSchedulePerDay() {
+        ScheduleDto scheduleDto1 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 19, 9, 30),
+                LocalDateTime.of(2024, 4, 19, 10, 30));
+        ScheduleDto scheduleDto2 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 19, 10, 30),
+                LocalDateTime.of(2024, 4, 19, 20, 0));
+        ScheduleDto scheduleDto3 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 19, 19, 30),
+                LocalDateTime.of(2024, 4, 19, 20, 30));
+
+        ScheduleDayRequest scheduleDayRequest1 = new ScheduleDayRequest(
+                new ArrayList<>(List.of(scheduleDto1, scheduleDto2, scheduleDto3)));
+
+        ScheduleCreateUpdateRequest scheduleCreateUpdateRequest =
+                new ScheduleCreateUpdateRequest(1L, List.of(scheduleDayRequest1));
+        Member member =
+                new Member(null, "namu", "namu2024@gmail.com", "", "", List.of("ROLE_USER"));
+        Project project = Project.builder()
+                .title("test").description("설명")
+                .startDate(LocalDate.of(2020, 1, 1))
+                .endDate(LocalDate.of(2025, 1, 1))
+                .startTime(LocalTime.MIN).endTime(LocalTime.MAX)
+                .daysOfWeek(Arrays.stream(DayOfWeek.values()).collect(Collectors.toSet()))
+                .memberProjects(new ArrayList<>()).invitations(new ArrayList<>())
+                .cover(null).color("FFFFFF")
+                .build();
+
+        Mockito.when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
+
+        Throwable exception = assertThrows(IllegalArgumentException.class, () ->
+                scheduleService.createSchedule(scheduleCreateUpdateRequest, 1L, CustomUserDetails.from(member)));
+        assertEquals(ExceptionMessage.INTERSECT_TIME.getMessage(), exception.getMessage());
+    }
+
+    @DisplayName("ScheduleDto의 start/end 시간이 30분 단위임을 검증한다.")
+    @Test
+    void validateIsMultipleOfHalfHourPerSchedule() {
+        ScheduleDto scheduleDto1 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 19, 9, 20),
+                LocalDateTime.of(2024, 4, 19, 10, 30));
+        ScheduleDto scheduleDto2 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 19, 10, 30),
+                LocalDateTime.of(2024, 4, 19, 12, 0));
+        ScheduleDto scheduleDto3 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 19, 19, 30),
+                LocalDateTime.of(2024, 4, 19, 20, 30));
+
+        ScheduleDayRequest scheduleDayRequest1 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto1, scheduleDto2, scheduleDto3)));
+
+        ScheduleCreateUpdateRequest scheduleCreateUpdateRequest =
+                new ScheduleCreateUpdateRequest(1L, List.of(scheduleDayRequest1));
+        Member member = new Member(null, "namu", "namu2024@gmail.com", "", "", List.of("ROLE_USER"));
+        Project project = Project.builder()
+                .title("test").description("설명")
+                .startDate(LocalDate.of(2020, 1, 1))
+                .endDate(LocalDate.of(2025, 1, 1))
+                .startTime(LocalTime.MIN).endTime(LocalTime.MAX)
+                .daysOfWeek(Arrays.stream(DayOfWeek.values()).collect(Collectors.toSet()))
+                .memberProjects(new ArrayList<>()).invitations(new ArrayList<>())
+                .cover(null).color("FFFFFF")
+                .build();
+
+        Mockito.when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
+
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> scheduleService.createSchedule(scheduleCreateUpdateRequest, 1L, CustomUserDetails.from(member)));
+        assertEquals(ExceptionMessage.INVALID_TIME_UNIT.getMessage(), exception.getMessage());
+    }
+
+    @DisplayName("ScheduleDto에서 start 시간 < end 시간임을 검증한다.")
+    @Test
+    void validateTimeSequencePerSchedule() {
+        ScheduleDto scheduleDto1 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 19, 10, 30),
+                LocalDateTime.of(2024, 4, 19, 9, 30));
+        ScheduleDto scheduleDto2 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 19, 10, 30),
+                LocalDateTime.of(2024, 4, 19, 12, 0));
+        ScheduleDto scheduleDto3 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 19, 19, 30),
+                LocalDateTime.of(2024, 4, 19, 20, 30));
+
+        ScheduleDayRequest scheduleDayRequest1 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto1, scheduleDto2, scheduleDto3)));
+
+
+        ScheduleCreateUpdateRequest scheduleCreateUpdateRequest =
+                new ScheduleCreateUpdateRequest(1L, List.of(scheduleDayRequest1));
+        Member member = new Member(null, "namu", "namu2024@gmail.com", "", "", List.of("ROLE_USER"));
+        Project project = Project.builder()
+                .title("test").description("설명")
+                .startDate(LocalDate.of(2020, 1, 1))
+                .endDate(LocalDate.of(2025, 1, 1))
+                .startTime(LocalTime.MIN).endTime(LocalTime.MAX)
+                .daysOfWeek(Arrays.stream(DayOfWeek.values()).collect(Collectors.toSet()))
+                .memberProjects(new ArrayList<>()).invitations(new ArrayList<>())
+                .cover(null).color("FFFFFF")
+                .build();
+
+        Mockito.when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
+
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> scheduleService.createSchedule(scheduleCreateUpdateRequest, 1L, CustomUserDetails.from(member)));
+        assertEquals(ExceptionMessage.INVALID_TIME_SEQUENCE.getMessage(), exception.getMessage());
+    }
+
+    @DisplayName("ScheduleDto의 start 날짜와 end 날짜가 같은지 검증한다.")
+    @Test
+    void validateIsSameDayPerSchedule() {
+        ScheduleDto scheduleDto1 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 19, 9, 30),
+                LocalDateTime.of(2024, 4, 19, 10, 30));
+        ScheduleDto scheduleDto2 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 19, 10, 30),
+                LocalDateTime.of(2024, 4, 19, 12, 0));
+        ScheduleDto scheduleDto3 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 19, 19, 30),
+                LocalDateTime.of(2024, 4, 20, 20, 30));
+
+        ScheduleDayRequest scheduleDayRequest1 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto1, scheduleDto2, scheduleDto3)));
+
+        ScheduleCreateUpdateRequest scheduleCreateUpdateRequest =
+                new ScheduleCreateUpdateRequest(1L, List.of(scheduleDayRequest1));
+        Member member = new Member(null, "namu", "namu2024@gmail.com", "", "", List.of("ROLE_USER"));
+        Project project = Project.builder()
+                .title("test").description("설명")
+                .startDate(LocalDate.of(2020, 1, 1))
+                .endDate(LocalDate.of(2025, 1, 1))
+                .startTime(LocalTime.MIN).endTime(LocalTime.MAX)
+                .daysOfWeek(Arrays.stream(DayOfWeek.values()).collect(Collectors.toSet()))
+                .memberProjects(new ArrayList<>()).invitations(new ArrayList<>())
+                .cover(null).color("FFFFFF")
+                .build();
+
+        Mockito.when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
+
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> scheduleService.createSchedule(scheduleCreateUpdateRequest, 1L, CustomUserDetails.from(member)));
+        assertEquals(ExceptionMessage.IS_NOT_SAME_DAY.getMessage(), exception.getMessage());
+    }
+
+    @DisplayName("ScheduleDto의 startTime~endTime이 프로젝트 시간 내인지 검증한다.")
+    @Test
+    void validateIsAppropriateTimePerSchedule() {
+        ScheduleDto scheduleDto1 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 19, 9, 30),
+                LocalDateTime.of(2024, 4, 19, 10, 30));
+        ScheduleDto scheduleDto2 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 19, 10, 30),
+                LocalDateTime.of(2024, 4, 19, 12, 0));
+        ScheduleDto scheduleDto3 = new ScheduleDto(
+                LocalDateTime.of(2024, 4, 19, 19, 30),
+                LocalDateTime.of(2024, 4, 19, 22, 30));
+
+        ScheduleDayRequest scheduleDayRequest1 = new ScheduleDayRequest(new ArrayList<>(List.of(scheduleDto1, scheduleDto2, scheduleDto3)));
+
+        ScheduleCreateUpdateRequest scheduleCreateUpdateRequest =
+                new ScheduleCreateUpdateRequest(1L, List.of(scheduleDayRequest1));
+        Member member = new Member(null, "namu", "namu2024@gmail.com", "", "", List.of("ROLE_USER"));
+        Project project = Project.builder()
+                .title("test").description("설명")
+                .startDate(LocalDate.of(2020, 1, 1))
+                .endDate(LocalDate.of(2025, 1, 1))
+                .startTime(LocalTime.of(9, 0)).endTime(LocalTime.of(22, 0))
+                .daysOfWeek(Arrays.stream(DayOfWeek.values()).collect(Collectors.toSet()))
+                .memberProjects(new ArrayList<>()).invitations(new ArrayList<>())
+                .cover(null).color("FFFFFF")
+                .build();
+
+        Mockito.when(projectRepository.findById(1L)).thenReturn(Optional.of(project));
+
+        Throwable exception = assertThrows(IllegalArgumentException.class, () -> scheduleService.createSchedule(scheduleCreateUpdateRequest, 1L, CustomUserDetails.from(member)));
+        assertEquals(ExceptionMessage.INVALID_PROJECT_TIME.getMessage(), exception.getMessage());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #32 
close #53 

## 📝작업 내용
1. 스케줄 조회
2. 스케줄 생성 & 수정
 - 검사가 조금 많습니다.
 - Week 기준
 - 1. 일주일(일-토요일) 단위의 요청이 맞는지 검사
 - 2. 중복된 날짜의 요청이 있는지 검사
 - 3. (생성 시 정했던)프로젝트 기간 내인지 검사
 - Day 기준
 - 1. 모든 ScheduleDto의 동일한 날짜인지 검사
 - 2. ScheduleDto 간 요청 시간이 중복/교차되는지 검사
 - 3. (생성 시 정했던)프로젝트 요일인지 검사
 - Schedule 하나 기준
 - 1. startTime, endTime이 30분 단위인지 검사
 - 2. startTime < endTime을 만족하는지 검사
 - 3. startDate == endDate를 만족하는지 검사
 - 4. (생성 시 정했던)프로젝트 시간 내인지 검사
3. 스케줄 삭제
 - start는 포함, end는 포함되지 않습니다.

4. 프로젝트 엔티티: 프로젝트 수행요일 -> Enum, 컬렉션(Set)으로 관리

## 💬리뷰 요구사항(선택)
1. 유효성검사 테스트는 만들긴했는데 케이스가 부족해서 확실치가 않네요. 터지는 것만 확인한 느낌입니다.
한 번 더 확인 부탁드립니다.

2. 스케줄 수정은 해당 주차 삭제 + 새로 생성의 역할을 합니다. => 스케줄 생성이 따로 필요할지?

## 추가
아직 고려되지 않은 사항
1. (프로젝트 범위 내)이미 지나간 기간에 스케줄을 추가하려고 한다면? 
2. 이미 생성한 주간 스케줄을 다시 한 번 생성 시 -> 기존것이 삭제되지 않은 채로 추가됨
3. ScheduleCreateUpdateRequest의 schedule,, 그리고 그 안에 schedule까지, 현재 비어있으면 안 됩니다.('schedule.get(0)'에서 NPE 터짐) 비거나 null이 들어오면 터지는 데 시도는 해봤으나 validation으로 잘 안 잡히네요.

추후 리팩터링
1. 조회 stream 개선
2. NPE  (위에 3번)
3. validate 로직 서비스에서 분리