### PR TITLE
상세페이지에서 관리자 권한을 가진 사용자를 식별할 수 있어야 합니다.

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/member/MemberResponse.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/member/MemberResponse.java
@@ -1,6 +1,7 @@
 package com.appcenter.timepiece.dto.member;
 
 import com.appcenter.timepiece.domain.Member;
+import com.appcenter.timepiece.domain.MemberProject;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,13 +19,16 @@ public class MemberResponse {
 
     private String profileImageUrl;
 
+    private Boolean isPrivileged;
+
     @Builder(access = AccessLevel.PRIVATE)
-    private MemberResponse(Long memberId, String email, String nickname, String state, String profileImageUrl) {
+    private MemberResponse(Long memberId, String email, String nickname, String state, String profileImageUrl, Boolean isPrivileged) {
         this.memberId = memberId;
         this.email = email;
         this.nickname = nickname;
         this.state = state;
         this.profileImageUrl = profileImageUrl;
+        this.isPrivileged = isPrivileged;
     }
 
     public static MemberResponse from(Member member) {
@@ -37,13 +41,14 @@ public class MemberResponse {
                 .build();
     }
 
-    public static MemberResponse of(Member member, String nickname) {
+    public static MemberResponse of(Member member, MemberProject memberProject) {
         return MemberResponse.builder()
                 .memberId(member.getId())
                 .email(member.getEmail())
-                .nickname(nickname)
+                .nickname(memberProject.getNickname())
                 .state(member.getState())
                 .profileImageUrl(member.getProfileImageUrl())
+                .isPrivileged(memberProject.getIsPrivileged())
                 .build();
     }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
@@ -98,7 +98,7 @@ public class ProjectService {
         return memberProjectRepository.findByProjectIdWithMember(projectId).stream()
                 .map(memberProject -> {
                     Member member = requireNonNull(memberProject.getMember()); // NPE!
-                    return MemberResponse.of(member, memberProject.getNickname());
+                    return MemberResponse.of(member, memberProject);
                 }).toList();
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #62 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

요구사항
- 상세페이지에서 프로젝트 관리자는 특별하게 나타나야 함

기존 멤버 목록 조회 API의 반환값의 권한 여부(isPrivileged) 필드를 추가하였습니다.

### 스크린샷 (선택)

![image (1)](https://github.com/Your-Lie-in-April/server/assets/121238128/2a502089-8220-4951-8d5e-e694dce98d16)

## 💬리뷰 요구사항(선택)

더 깔끔한 방법이 생각나면 꼭 말씀해주세요!