### PR TITLE
메인페이지 프로젝트 검색, 조회에 보관된 프로젝트가 포함되지 않도록 변경하였습니다.

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/repository/MemberProjectRepository.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/repository/MemberProjectRepository.java
@@ -16,7 +16,7 @@ public interface MemberProjectRepository extends JpaRepository<MemberProject, Lo
     @Query("select mp from MemberProject mp " +
             "join fetch mp.project p " +
             "left join fetch p.cover c " +
-            "where mp.member.id = :memberId")
+            "where mp.member.id = :memberId and mp.isStored=false")
     Page<MemberProject> findMemberProjectsWithProjectAndCover(Pageable pageable, Long memberId);
 
     @Query("select mp from MemberProject mp " +

--- a/timepiece/src/main/java/com/appcenter/timepiece/repository/ProjectRepository.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/repository/ProjectRepository.java
@@ -12,14 +12,14 @@ import java.util.List;
 @Repository
 public interface ProjectRepository extends JpaRepository<Project, Long> {
 
-    @Query("select p from Project p left join fetch p.cover c")
+    @Query("select p from Project p left  join fetch p.cover c")
     List<Project> findAllWithCover();
 
     @Query("select distinct p from Project p " +
             "join p.memberProjects mp " +
             "join mp.member m " +
             "where m.id = :memberId and p.title like %:keyword% and mp.isStored = false ")
-    List<Project> findProjectByMemberIdAndTitleLikeKeyword(Pageable pageable, Long memberId, String keyword);
+    Page<Project> findProjectByMemberIdAndTitleLikeKeyword(Pageable pageable, Long memberId, String keyword);
 
     @Query("select distinct p from Project p " +
             "join p.memberProjects mp " +

--- a/timepiece/src/main/java/com/appcenter/timepiece/repository/ProjectRepository.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/repository/ProjectRepository.java
@@ -18,8 +18,8 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
     @Query("select distinct p from Project p " +
             "join p.memberProjects mp " +
             "join mp.member m " +
-            "where m.id = :memberId and p.title like %:keyword%")
-    Page<Project> findProjectByMemberIdAndTitleLikeKeyword(Pageable pageable, Long memberId, String keyword);
+            "where m.id = :memberId and p.title like %:keyword% and mp.isStored = false ")
+    List<Project> findProjectByMemberIdAndTitleLikeKeyword(Pageable pageable, Long memberId, String keyword);
 
     @Query("select distinct p from Project p " +
             "join p.memberProjects mp " +


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #64 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 어떤 버그인가요?

아래 두 API의 조회 결과, 보관처리된 프로젝트는 포함하지 않도록 수정했습니다.
JPQL의 where절에 memberProject.isStored 속성이 false인 경우만 조회되도록 변경했습니다.
- 소속 프로젝트 전체 조회(썸네일)
- 유저가 가지고 있는 프로젝트 중 검색

