### PR TITLE
프로젝트 검색 기능에 보관여부 필터를 추가했습니다.

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
@@ -48,10 +48,13 @@ public class ProjectController {
 
     @GetMapping("/v1/projects/members/{memberId}/{keyword}")
     @Operation(summary = "유저가 가지고 있는 프로젝트 중 검색", description = "")
-    public ResponseEntity<CommonResponse<?>> searchProjects(Integer page, Integer size, @PathVariable Long memberId,
-                                                            @PathVariable String keyword, @AuthenticationPrincipal UserDetails userDetails) {
+    public ResponseEntity<CommonResponse<?>> searchProjects(Integer page, Integer size,
+                                                            @PathVariable Long memberId,
+                                                            @PathVariable String keyword,
+                                                            @RequestParam(defaultValue = "false", required = false) Boolean isStored,
+                                                            @AuthenticationPrincipal UserDetails userDetails) {
         return ResponseEntity.ok().body(CommonResponse.success("프로젝트 검색 성공",
-                projectService.searchProjects(page, size, memberId, keyword, userDetails)));
+                projectService.searchProjects(page, size, isStored, memberId, keyword, userDetails)));
     }
 
     // todo: 해당 기능은 Project가 아닌 Member의 책임이 아닐까?

--- a/timepiece/src/main/java/com/appcenter/timepiece/repository/ProjectRepository.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/repository/ProjectRepository.java
@@ -12,14 +12,14 @@ import java.util.List;
 @Repository
 public interface ProjectRepository extends JpaRepository<Project, Long> {
 
-    @Query("select p from Project p left  join fetch p.cover c")
+    @Query("select p from Project p left join fetch p.cover c")
     List<Project> findAllWithCover();
 
     @Query("select distinct p from Project p " +
             "join p.memberProjects mp " +
             "join mp.member m " +
-            "where m.id = :memberId and p.title like %:keyword% and mp.isStored = false ")
-    Page<Project> findProjectByMemberIdAndTitleLikeKeyword(Pageable pageable, Long memberId, String keyword);
+            "where m.id = :memberId and p.title like %:keyword% and mp.isStored = :isStored")
+    Page<Project> findProjectByMemberIdAndTitleLikeKeyword(Pageable pageable, Boolean isStored, Long memberId, String keyword);
 
     @Query("select distinct p from Project p " +
             "join p.memberProjects mp " +

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
@@ -94,11 +94,11 @@ public class ProjectService {
     }
 
     @Transactional
-    public List<ProjectThumbnailResponse> searchProjects(Integer page, Integer size, Long memberId, String keyword, UserDetails userDetails) {
+    public List<ProjectThumbnailResponse> searchProjects(Integer page, Integer size, Boolean isStored, Long memberId, String keyword, UserDetails userDetails) {
         validateMemberIsOwner(memberId, userDetails);
 
         PageRequest pageable = PageRequest.of(page, size);
-        Page<Project> projectPage = projectRepository.findProjectByMemberIdAndTitleLikeKeyword(pageable, memberId, keyword);
+        Page<Project> projectPage = projectRepository.findProjectByMemberIdAndTitleLikeKeyword(pageable, isStored, memberId, keyword);
         List<Project> projects = projectPage.getContent();
         List<ProjectThumbnailResponse> projectThumbnailResponses = projects.stream()
                 .map(p -> ProjectThumbnailResponse.of(p, ((p.getCover() == null) ? null : p.getCover().getCoverImageUrl()))).toList();


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #66 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

프로젝트 검색 기능을 메인/보관함 모두에서 사용할 수 있습니다.
보관 여부(isStored)로 검색 결과를 조절할 수 있으며, 입력하지 않을 시 기본적으로 보관처리하지 않은 프로젝트만을 검색합니다.
