### PR TITLE
Feature/61 oauth2 add social type

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/common/security/JwtAuthFilter.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/security/JwtAuthFilter.java
@@ -35,7 +35,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             log.info("[doFilterInternal] jwtToken:{}", jwtToken);
 
             log.info("[doFilterInternal] 토큰 타입 확인");
-            if (servletRequest.getRequestURI().equals("/v1/oauth2/reissue")) {
+            if (servletRequest.getRequestURI().equals("/v1/auth/reissue")) {
                 jwtProvider.validRefreshToken(jwtToken);
             } else {
                 jwtProvider.validAccessToken(jwtToken);

--- a/timepiece/src/main/java/com/appcenter/timepiece/common/security/OAuth2Attributes.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/security/OAuth2Attributes.java
@@ -17,27 +17,25 @@ public class OAuth2Attributes {
     private String email;
     private String profileImageUrl;
     private String provider;
-    private String oauth2Id;
 
     @Builder
     public OAuth2Attributes(Map<String, Object> attributes, String nameAttributesKey,
-                            String name, String email, String profileImageUrl, String provider, String oauth2Id) {
+                            String name, String email, String profileImageUrl, String provider) {
         this.attributes = attributes;
         this.nameAttributesKey = nameAttributesKey;
         this.name = name;
         this.email = email;
         this.profileImageUrl = profileImageUrl;
         this.provider = provider;
-        this.oauth2Id = oauth2Id;
     }
 
     public static OAuth2Attributes of(String socialName, Map<String, Object> attributes) {
         if ("kakao".equals(socialName)) {
-            return ofKakao("id", attributes);
+            return ofKakao("email", attributes);
         } else if ("google".equals(socialName)) {
-            return ofGoogle("sub", attributes);
+            return ofGoogle("email", attributes);
         }
-        return ofGithub("id", attributes);
+        return ofGithub("login", attributes);
     }
 
 
@@ -49,7 +47,6 @@ public class OAuth2Attributes {
                 .attributes(attributes)
                 .nameAttributesKey(userNameAttributeName)
                 .provider("google")
-                .oauth2Id(String.valueOf(attributes.get(userNameAttributeName)))
                 .build();
     }
 
@@ -61,10 +58,9 @@ public class OAuth2Attributes {
                 .name(String.valueOf(kakaoProfile.get("nickname")))
                 .email(String.valueOf(kakaoAccount.get("email")))
                 .profileImageUrl(String.valueOf(kakaoProfile.get("profile_image_url")))
-                .attributes(attributes)
+                .attributes(kakaoAccount)
                 .nameAttributesKey(userNameAttributeName)
                 .provider("kakao")
-                .oauth2Id(String.valueOf(attributes.get(userNameAttributeName)))
                 .build();
     }
 
@@ -76,7 +72,6 @@ public class OAuth2Attributes {
                 .attributes(attributes)
                 .nameAttributesKey(userNameAttributeName)
                 .provider("github")
-                .oauth2Id(String.valueOf(attributes.get(userNameAttributeName)))
                 .build();
     }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/common/security/OAuth2SuccessHandler.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/security/OAuth2SuccessHandler.java
@@ -75,7 +75,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         return UriComponentsBuilder.newInstance()
                 .scheme(frontScheme)
                 .host(frontHost)
-                //.port(frontPort)
+                .port(frontPort)
                 .path(frontPath)
                 .queryParams(queryParams)
                 .build()

--- a/timepiece/src/main/java/com/appcenter/timepiece/common/security/OAuth2SuccessHandler.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/security/OAuth2SuccessHandler.java
@@ -47,7 +47,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
         DefaultOAuth2User oAuth2User = (DefaultOAuth2User) authentication.getPrincipal();
-        Member member = memberRepository.findByOauth2Id(oAuth2User.getName()).get();
+        Member member = memberRepository.findByEmail(oAuth2User.getName()).get();
 
         redirectToken(request, response, member);
     }

--- a/timepiece/src/main/java/com/appcenter/timepiece/common/security/OAuth2SuccessHandler.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/security/OAuth2SuccessHandler.java
@@ -75,7 +75,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         return UriComponentsBuilder.newInstance()
                 .scheme(frontScheme)
                 .host(frontHost)
-                .port(frontPort)
+                //.port(frontPort)
                 .path(frontPath)
                 .queryParams(queryParams)
                 .build()

--- a/timepiece/src/main/java/com/appcenter/timepiece/domain/Member.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/domain/Member.java
@@ -19,8 +19,6 @@ public class Member extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String oauth2Id;
-
     private String provider;
 
     @Column(nullable = false)
@@ -43,8 +41,7 @@ public class Member extends BaseTimeEntity {
 
 
     @Builder
-    public Member(String provider, String oauth2Id, String nickname, String email, String state, String profileImageUrl, List<String> role) {
-        this.oauth2Id = oauth2Id;
+    public Member(String provider, String nickname, String email, String state, String profileImageUrl, List<String> role) {
         this.provider = provider;
         this.nickname = nickname;
         this.email = email;

--- a/timepiece/src/main/java/com/appcenter/timepiece/repository/MemberRepository.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/repository/MemberRepository.java
@@ -8,6 +8,4 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
-
-    Optional<Member> findByOauth2Id(String oauth2Id);
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/repository/MemberRepository.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/repository/MemberRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByEmailAndProvider(String email, String provider);
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/CustomOAuth2Service.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/CustomOAuth2Service.java
@@ -46,7 +46,7 @@ public class CustomOAuth2Service implements OAuth2UserService<OAuth2UserRequest,
         Optional<Member> member = memberRepository.findByEmail(authAttributes.getEmail());
         Member returnMember;
         if (member.isEmpty()) {
-            returnMember = new Member(provider, authAttributes.getOauth2Id(), authAttributes.getName(),
+            returnMember = new Member(provider, authAttributes.getName(),
                     authAttributes.getEmail(), "", authAttributes.getProfileImageUrl(), List.of("ROLE_USER"));
         } else {
             returnMember = member.get().updateMember(authAttributes.getName(), authAttributes.getProfileImageUrl());


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #61

## 📝작업 내용

Oauth2 로그인 기능에 카카오와 github를 추가했습니다.

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

현재 DefaultOauth2User를 반환하고 있습니다.
kakao의 제공 attributes가 email을 따로 반환하지 않고 다른 정보와 함께 json으로 반환해서 똑같은 로직을 적용할 수 없어서 현재 세개 모두 oauth2 고유 아이디를 입력받아서 유저를 구분하고 있습니다(oauth2 email과 oauth2pk(테이블명: oauth2Id))

이렇게 일단락되는가 했지만 google의 oauth2 pk가 혼자 BIGINT라서... 그럼 자료형 변환을 한번 로그인할때마다 3번 4번 해야하니까(object->String->BIGINT) 일단 String으로 해놨는데 

1. 그냥 oauth2User 반환형을 만들어서(UserDetails에 같이 구현) 반환하자
2. 지금 이대로 가자
3. BigInt 쓰자

뭐가 맞다고 생각하시는지요...
