### PR TITLE
Feature/50 security config endpoint setting

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/common/security/SecurityConfig.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/security/SecurityConfig.java
@@ -46,16 +46,15 @@ public class SecurityConfig {
                         sessionManagement
                                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/v1/members/**").authenticated()
-                        .requestMatchers("/v1/oauth2/login-page/google").permitAll()
                         .requestMatchers("/oauth2/**").permitAll()
-                        .requestMatchers("/v1/oauth2/reissue").hasRole("USER")
-                        .requestMatchers("/v1/oauth2/test").hasRole("USER")
-                        .requestMatchers("/v1/oauth2/test1").permitAll()
-                        .requestMatchers("/v1/projects/**").hasRole("USER")
-                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        .requestMatchers("/v1/projects/**").hasRole("USER")
                         .requestMatchers("/login/**").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+
+                        .requestMatchers("/v1/oauth2/reissue").hasRole("USER")
+                        .requestMatchers("/v1/members/**").hasRole("USER")
+                        .requestMatchers("/v1/projects/**").hasRole("USER")
+                        .requestMatchers("/v1/invitation/{url}").permitAll()
+
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/timepiece/src/main/java/com/appcenter/timepiece/common/security/SecurityConfig.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.appcenter.timepiece.service.CustomOAuth2Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
@@ -46,15 +47,12 @@ public class SecurityConfig {
                         sessionManagement
                                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/oauth2/**").permitAll()
-                        .requestMatchers("/login/**").permitAll()
-                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-
-                        .requestMatchers("/v1/oauth2/reissue").hasRole("USER")
-                        .requestMatchers("/v1/members/**").hasRole("USER")
-                        .requestMatchers("/v1/projects/**").hasRole("USER")
-                        .requestMatchers("/v1/invitation/{url}").permitAll()
-
+                        .requestMatchers(PERMIT_ALL).permitAll()
+                        .requestMatchers(HttpMethod.GET, PERMIT_USER_GET).hasRole("USER")
+                        .requestMatchers(HttpMethod.POST, PERMIT_USER_POST).hasRole("USER")
+                        .requestMatchers(HttpMethod.DELETE, PERMIT_USER_DELETE).hasRole("USER")
+                        .requestMatchers(HttpMethod.PUT, PERMIT_USER_PUT).hasRole("USER")
+                        .requestMatchers(HttpMethod.PATCH, PERMIT_USER_PATCH).hasRole("USER")
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
@@ -89,4 +87,50 @@ public class SecurityConfig {
         source.registerCorsConfiguration("/**", configuration);
         return source;
     }
+
+    String[] PERMIT_ALL = {
+            "/oauth2/**", //oauth2 로그인 서비스 접근
+            "/login/**", //oauth2 로그인창
+            "/swagger-ui/**", //스웨거 명세
+            "/v3/api-docs/**", //스웨거 명세
+            "/v1/invitation/{url}" //회원 초대(추가)
+    };
+
+    String[] PERMIT_USER_GET = {
+            "/v1/members/{memberId}", //회원정보 조회
+            "/v1/projects/members/{memberId}", //소속 프로젝트 전체 조회
+            "/v1/projects/members/{memberId}/pin", //핀 설정된 프로젝트 조회(+시간표)
+            "/v1/projects/members/{memberId}/{keyword}", //유저가 가지고 있는 프로젝트 중 검색
+            "/v1/projects/{projectId}/members", //프로젝트에 속해있는 유저 전체 조회
+            "/v1/projects/stored", //보관한 프로젝트 목록 조회
+            "/v1/projects/{projectId}/schedules", //프로젝트 내 모든 사용자 시간표 조회
+            "/v1/projects/{projectId}/members/{memberId}/schedules" //사용자 시간표 조회
+    };
+
+    String[] PERMIT_USER_POST = {
+            "/v1/projects", //프로젝트 생성
+            "/v1/projects/{projectId}/invitation", //초대링크 생성
+            "/v1/projects/{projectId}/schedules", //시간표 생성
+            "/v1/auth/reissue" //리프레시 토큰 재생성
+    };
+
+    String[] PERMIT_USER_PUT = {
+            "/v1/members/{state}", //상태메시지 설정
+            "/v1/projects/members/nickname", //닉네임 재설정
+            "/v1/projects/{projectId}", //프로젝트 수정
+            "/v1/projects/{projectId}/schedules" //시간표 수정
+    };
+
+    String[] PERMIT_USER_PATCH = {
+            "/v1/members/storage/{projectId}", //프로젝트 보관-해제
+            "/v1/members/pin/{projectId}", //프로젝트 핀 설정-해제
+            "/v1/projects/{projectId}/transfer-privilege" //관리자 권한 양도
+    };
+
+    String[] PERMIT_USER_DELETE = {
+            "/v1/projects/{projectId}", // 프로젝트 삭제
+            "/v1/projects/{projectId}/members/{memberId}", //프로젝트에서 회원 강퇴
+            "/v1/projects/{projectId}/me", //프로젝트 스스로 나가기
+            "/v1/projects/{projectId}/schedules" //시간표 삭제
+    };
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/AuthController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/AuthController.java
@@ -31,17 +31,4 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.OK).body(new CommonResponse(1, "토큰 재발급 성공", authService.reissueAccessToken(request)));
     }
 
-    @GetMapping(value = "/v1/auth/test")
-    @Operation(summary = "테스트API", description = "")
-    @SwaggerApiResponses
-    public ResponseEntity<CommonResponse> testApi(@AuthenticationPrincipal UserDetails userDetails) {
-        return ResponseEntity.status(HttpStatus.OK).body(new CommonResponse(1, "테스트 성공", authService.testApi(userDetails)));
-    }
-
-    @GetMapping(value = "/v1/auth/test1")
-    @Operation(summary = "테스트API", description = "")
-    @SwaggerApiResponses
-    public ResponseEntity<CommonResponse> testApi1(@AuthenticationPrincipal UserDetails userDetails) {
-        return ResponseEntity.status(HttpStatus.OK).body(new CommonResponse(1, "테스트 성공", authService.testApi(userDetails)));
-    }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/AuthController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/AuthController.java
@@ -10,9 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,7 +22,7 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @GetMapping(value = "/v1/auth/reissue")
+    @PostMapping(value = "/v1/auth/reissue")
     @Operation(summary = "토큰 재발급", description = "")
     @SwaggerApiResponses
     public ResponseEntity<CommonResponse> reissueAccessToken(HttpServletRequest request) {

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
@@ -93,7 +93,7 @@ public class ProjectController {
         return ResponseEntity.ok().body(CommonResponse.success("프로젝트 생성 성공", null));
     }
 
-    @PutMapping("/v1/projects/{projectId}")
+    @PatchMapping("/v1/projects/{projectId}")
     @Operation(summary = "프로젝트 삭제", description = "")
     public ResponseEntity<CommonResponse<?>> kickProject(@PathVariable Long projectId,
                                                          @AuthenticationPrincipal UserDetails userDetails) {

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
@@ -93,7 +93,7 @@ public class ProjectController {
         return ResponseEntity.ok().body(CommonResponse.success("프로젝트 생성 성공", null));
     }
 
-    @DeleteMapping("/v1/projects/{projectId}")
+    @PutMapping("/v1/projects/{projectId}")
     @Operation(summary = "프로젝트 삭제", description = "")
     public ResponseEntity<CommonResponse<?>> kickProject(@PathVariable Long projectId,
                                                          @AuthenticationPrincipal UserDetails userDetails) {

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
@@ -93,7 +93,7 @@ public class ProjectController {
         return ResponseEntity.ok().body(CommonResponse.success("프로젝트 생성 성공", null));
     }
 
-    @PatchMapping("/v1/projects/{projectId}")
+    @DeleteMapping("/v1/projects/{projectId}")
     @Operation(summary = "프로젝트 삭제", description = "")
     public ResponseEntity<CommonResponse<?>> kickProject(@PathVariable Long projectId,
                                                          @AuthenticationPrincipal UserDetails userDetails) {

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
@@ -80,7 +80,7 @@ public class ProjectController {
     @Operation(summary = "보관 프로젝트 목록 조회", description = "")
     public ResponseEntity<CommonResponse<?>> findStoredProjects(
             @RequestParam(defaultValue = "0", required = false) Integer page,
-            @RequestParam(defaultValue = "6", required = false) Integer size, @AuthenticationPrincipal UserDetails userDetails) {
+            @RequestParam(defaultValue = "9", required = false) Integer size, @AuthenticationPrincipal UserDetails userDetails) {
         return ResponseEntity.ok().body(CommonResponse.success("보관 프로젝트 목록 조회 성공",
                 projectService.findStoredProjects(page, size, userDetails)));
     }

--- a/timepiece/src/main/java/com/appcenter/timepiece/domain/Project.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/domain/Project.java
@@ -42,8 +42,8 @@ public class Project extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @ElementCollection(fetch = FetchType.EAGER)
-    @CollectionTable(name="project_days_of_week",
-            joinColumns = @JoinColumn(name= "project_id"))
+    @CollectionTable(name = "project_days_of_week",
+            joinColumns = @JoinColumn(name = "project_id"))
     private Set<DayOfWeek> daysOfWeek;
 
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL)
@@ -58,11 +58,13 @@ public class Project extends BaseTimeEntity {
 
     private String color;
 
+    private Boolean isDeleted;
+
     @Builder
     private Project(String title, String description,
                     LocalDate startDate, LocalDate endDate, LocalTime startTime, LocalTime endTime,
                     Set<DayOfWeek> daysOfWeek, List<MemberProject> memberProjects, List<Invitation> invitations,
-                    Cover cover, String color) {
+                    Cover cover, String color, Boolean isDeleted) {
         this.title = title;
         this.description = description;
         this.startDate = startDate;
@@ -74,6 +76,7 @@ public class Project extends BaseTimeEntity {
         this.invitations = invitations;
         this.cover = cover;
         this.color = color;
+        this.isDeleted = isDeleted;
     }
 
     public static Project of(ProjectCreateUpdateRequest request, Cover cover) {
@@ -85,6 +88,7 @@ public class Project extends BaseTimeEntity {
                 .daysOfWeek(request.getDaysOfWeek())
                 .color(request.getColor())
                 .cover(cover)
+                .isDeleted(false)
                 .build();
     }
 
@@ -99,4 +103,5 @@ public class Project extends BaseTimeEntity {
         this.color = request.getColor();
         this.cover = cover;
     }
+
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/domain/Project.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/domain/Project.java
@@ -104,7 +104,7 @@ public class Project extends BaseTimeEntity {
         this.cover = cover;
     }
 
-    public void updateDeleteStatus(Long projectId) {
+    public void updateDeleteStatus() {
         this.isDeleted = true;
     }
 

--- a/timepiece/src/main/java/com/appcenter/timepiece/domain/Project.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/domain/Project.java
@@ -104,4 +104,8 @@ public class Project extends BaseTimeEntity {
         this.cover = cover;
     }
 
+    public void updateDeleteStatus(Long projectId) {
+        this.isDeleted = true;
+    }
+
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/AuthService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/AuthService.java
@@ -65,17 +65,5 @@ public class AuthService {
         return tokenResponse;
     }
 
-    public String testApi(UserDetails userDetails) {
-        log.info("[testApi] memberId 추출중");
-
-        Long memberId = ((CustomUserDetails) userDetails).getId();
-        log.info("[testApi] memberId 추출 성공. memberId = {}", memberId);
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.MEMBER_NOT_FOUND));
-        log.info("[testApi] member 찾기 성공. memberEmail = {}", member.getEmail());
-
-        return member.toString();
-    }
-
 
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
@@ -158,7 +158,7 @@ public class ProjectService {
         validateRequesterIsPrivileged(projectId, userDetails);
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.PROJECT_NOT_FOUND));
-        project.updateDeleteStatus(projectId);
+        project.updateDeleteStatus();
 
         projectRepository.save(project);
     }

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
@@ -158,7 +158,9 @@ public class ProjectService {
         validateRequesterIsPrivileged(projectId, userDetails);
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.PROJECT_NOT_FOUND));
-        projectRepository.delete(project);
+        project.updateDeleteStatus(projectId);
+
+        projectRepository.save(project);
     }
 
     @Transactional


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #50

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 보관 프로젝트 paging defalut값 변경(6->9)
2. securityConfig 권한 배열으로 관리
3. refreshToken reissue 메소드 GET -> POST로 변경

### 스크린샷 (선택)

![image](https://github.com/Your-Lie-in-April/server/assets/92552047/93914528-9586-4df0-801a-fc5e9585e337)
![image](https://github.com/Your-Lie-in-April/server/assets/92552047/1a71603f-4baf-42e9-8b84-0cc231325e25)
![image](https://github.com/Your-Lie-in-April/server/assets/92552047/675b626d-64a6-420f-908f-c7b2712ce4a4)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

그냥 url 정리용으로 파일을 더 만드는게 나을까요

그리고 .hasRole 여러번 쓰는게 너무 거슬리는데 람다같은 방법으로 처리 할 방법을 혹시 알고계신가요... 검색 하는 능력이 모자라서 그런가 원하는 방법이 안나오네요...