### PR TITLE
사용자 초대 페이지를 위한 초대 정보 조회

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/common/security/SecurityConfig.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/security/SecurityConfig.java
@@ -104,7 +104,8 @@ public class SecurityConfig {
             "/v1/projects/{projectId}/members", //프로젝트에 속해있는 유저 전체 조회
             "/v1/projects/stored", //보관한 프로젝트 목록 조회
             "/v1/projects/{projectId}/schedules", //프로젝트 내 모든 사용자 시간표 조회
-            "/v1/projects/{projectId}/members/{memberId}/schedules" //사용자 시간표 조회
+            "/v1/projects/{projectId}/members/{memberId}/schedules", //사용자 시간표 조회
+            "/v1/projects/invitations" //프로젝트 초대 정보 조회
     };
 
     String[] PERMIT_USER_POST = {

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
@@ -118,6 +118,13 @@ public class ProjectController {
                 projectService.generateInviteLink(projectId, userDetails));
     }
 
+    @GetMapping("/v1/projects/invitations")
+    @Operation(summary = "초대 링크 메타데이터 조회", description = "")
+    public CommonResponse<?> generateInviteLink(@RequestParam(required = true) String url) {
+        return CommonResponse.success("초대링크 정보를 성공적으로 조회했습니다",
+                projectService.decodeInviteLink(url));
+    }
+
     @DeleteMapping("/v1/projects/{projectId}/members/{memberId}")
     @Operation(summary = "회원 강퇴", description = "")
     public CommonResponse<Void> kick(@PathVariable Long projectId,

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/project/InvitationResponse.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/project/InvitationResponse.java
@@ -1,0 +1,25 @@
+package com.appcenter.timepiece.dto.project;
+
+import com.appcenter.timepiece.domain.Project;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class InvitationResponse {
+    String title;
+    String invitator;
+    Boolean isExpired;
+
+    private InvitationResponse(String title, String invitator, Boolean isExpired) {
+        this.title = title;
+        this.invitator = invitator;
+        this.isExpired = isExpired;
+    }
+
+    public static InvitationResponse of(Project project, String invitator, LocalDateTime linkTime) {
+        return new InvitationResponse(project.getTitle(), invitator, linkTime.isBefore(LocalDateTime.now()));
+    }
+}

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
@@ -295,4 +295,14 @@ public class ProjectService {
         return projectThumbnailResponses;
     }
 
+    public InvitationResponse decodeInviteLink(String url) {
+        StringTokenizer st = new StringTokenizer(aesEncoder.decryptAES256(url), "?");
+        Long projectId = Long.valueOf(st.nextToken());
+        String invitator = st.nextToken();
+        LocalDateTime linkTime = LocalDateTime.parse(st.nextToken());
+
+        Project project = projectRepository.findById(projectId).orElseThrow(() -> new NotFoundElementException(ExceptionMessage.PROJECT_NOT_FOUND));
+        return InvitationResponse.of(project, invitator, linkTime);
+
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #81 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

초대 링크를 받아 초대 정보를 조회할 수 있는 API를 작성했습니다.
data
- title: 초대받은 프로젝트 제목입니다.
- invitator: 초대자 이름입니다.
- isExpired: 현재 링크의 만료여부를 나타냅니다.
