### PR TITLE
프로젝트 초대링크 생성 시, 관련된 프로젝트의 제목 및 ID 정보 반환

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/project/InvitationLinkResponse.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/project/InvitationLinkResponse.java
@@ -1,0 +1,23 @@
+package com.appcenter.timepiece.dto.project;
+
+import com.appcenter.timepiece.domain.Project;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class InvitationLinkResponse {
+    Long projectId;
+    String title;
+    String link;
+
+    private InvitationLinkResponse(Long projectId, String title, String link) {
+        this.projectId = projectId;
+        this.title = title;
+        this.link = link;
+    }
+
+    public static InvitationLinkResponse of(Project project, String link) {
+        return new InvitationLinkResponse(project.getId(), project.getTitle(), link);
+    }
+}

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
@@ -185,7 +185,7 @@ public class ProjectService {
         memberProjectRepository.delete(memberProject);
     }
 
-    public String generateInviteLink(Long projectId, UserDetails userDetails) {
+    public InvitationLinkResponse generateInviteLink(Long projectId, UserDetails userDetails) {
         validateRequesterIsPrivileged(projectId, userDetails);
 
         Member member = memberRepository.findById(((CustomUserDetails) userDetails).getId())
@@ -200,7 +200,8 @@ public class ProjectService {
 
         String url = aesEncoder.encryptAES256(urlData);
         invitationRepository.save(Invitation.of(project, url));
-        return url;
+
+        return InvitationLinkResponse.of(project, url);
     }
 
     @Transactional


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #100 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
<img width="687" alt="스크린샷 2024-06-15 오후 6 48 45" src="https://github.com/Your-Lie-in-April/server/assets/121238128/e8f4ea2b-88ca-453d-8c54-d23164cf192e">

초대링크 생성 API의 응답에 프로젝트 제목 및 id를 포함시켰습니다.
- InvitationLinkResponse 클래스 추가

### 스크린샷 (선택)

![image](https://github.com/Your-Lie-in-April/server/assets/121238128/0d54c82a-cf1b-4776-9a4b-4791b192b413)