### PR TITLE
알림의 확인 및 삭제 시 조회 결과

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/NotificationController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/NotificationController.java
@@ -32,7 +32,7 @@ public class NotificationController {
 
     @Operation(summary = "이전 알림 조회", description = "DB에 저장된 알림을 조회합니다.")
     @GetMapping(value = "/v1/notifications")
-    public CommonResponse<?> subscribe(@RequestParam(defaultValue = "0", required = false) Integer page,
+    public CommonResponse<?> getNotifications(@RequestParam(defaultValue = "0", required = false) Integer page,
                                        @RequestParam(defaultValue = "12", required = false) Integer size,
                                        @AuthenticationPrincipal UserDetails userDetails) {
         return CommonResponse.success("알림 조회에 성공했습니다.",notificationService.getNotifications(page, size, userDetails));
@@ -40,7 +40,7 @@ public class NotificationController {
 
     @Operation(summary = "(프로젝트 내)이전 알림 조회", description = "DB에 저장된 특정 프로젝트의 알림을 조회합니다.")
     @GetMapping(value = "/v1/projects/{projectId}/notifications")
-    public CommonResponse<?> subscribe(@RequestParam(defaultValue = "0", required = false) Integer page,
+    public CommonResponse<?> getNotificationsInProject(@RequestParam(defaultValue = "0", required = false) Integer page,
                                        @RequestParam(defaultValue = "12", required = false) Integer size,
                                        @PathVariable Long projectId,
                                        @AuthenticationPrincipal UserDetails userDetails) {

--- a/timepiece/src/main/java/com/appcenter/timepiece/repository/NotificationRepository.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/repository/NotificationRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
-    Page<Notification> findByReceiverId(Pageable pageable, Long receiverId);
-    Page<Notification> findByReceiverIdAndProjectId(Pageable pageable, Long receiverId, Long projectId);
+    Page<Notification> findByReceiverIdAndIsDeletedIsFalse(Pageable pageable, Long receiverId);
+    Page<Notification> findByReceiverIdAndProjectIdAndIsDeletedIsFalse(Pageable pageable, Long receiverId, Long projectId);
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/NotificationService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/NotificationService.java
@@ -174,7 +174,7 @@ public class NotificationService {
         Sort strategy = Sort.by(Sort.Direction.ASC, "isChecked")
                 .and(Sort.by(Sort.Direction.DESC, "createdAt"));
 
-        return notificationRepository.findByReceiverId(PageRequest.of(page, size, strategy), memberId).stream()
+        return notificationRepository.findByReceiverIdAndIsDeletedIsFalse(PageRequest.of(page, size, strategy), memberId).stream()
                 .map(NotificationResponse::from).toList();
     }
 
@@ -183,7 +183,7 @@ public class NotificationService {
         Long memberId = ((CustomUserDetails) userDetails).getId();
         Sort strategy = Sort.by(Sort.Direction.ASC, "isChecked")
                 .and(Sort.by(Sort.Direction.DESC, "createdAt"));
-        return notificationRepository.findByReceiverIdAndProjectId(PageRequest.of(page, size, strategy), memberId, projectId).stream()
+        return notificationRepository.findByReceiverIdAndProjectIdAndIsDeletedIsFalse(PageRequest.of(page, size, strategy), memberId, projectId).stream()
                 .map(NotificationResponse::from).toList();
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #104 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

알림의 상태에 따라 쿼리 API의 결과가 달라지도록 수정하였습니다.
1. isDeleted=true이면, 조회 결과에서 제외된다.
2. isChecked=true이면, 조회 결과에서 isChecked=false인 모든 알림 뒤에 조회된다.

### 스크린샷 (선택)

<img width="634" alt="스크린샷 2024-06-17 오후 11 06 38" src="https://github.com/Your-Lie-in-April/server/assets/121238128/74c81981-1190-4813-ba64-a000875f7015">
<img width="867" alt="스크린샷 2024-06-17 오후 11 06 58" src="https://github.com/Your-Lie-in-April/server/assets/121238128/a0961182-5879-4af7-92fb-d3832bc7abf2">

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

QueryDSL 적용 이후 추가하려고 했는데 생각보다 늦어져서 먼저 추가했습니다.
