### PR TITLE
Pagination이 포함된 API에 페이징 관련 공통 응답을 추가했습니다.

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/common/dto/CommonPagingResponse.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/dto/CommonPagingResponse.java
@@ -1,0 +1,22 @@
+package com.appcenter.timepiece.common.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommonPagingResponse<T> {
+    private Integer currentPage;
+    private Integer pageSize;
+    private Long totalCount;
+    private Integer totalPages;
+    private T data;
+
+    public CommonPagingResponse(Integer currentPage, Integer pageSize, Long totalCount, Integer totalPages, T data) {
+        this.currentPage = currentPage;
+        this.pageSize = pageSize;
+        this.totalCount = totalCount;
+        this.totalPages = totalPages;
+        this.data = data;
+    }
+}

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
@@ -2,7 +2,6 @@ package com.appcenter.timepiece.controller;
 
 import com.appcenter.timepiece.common.dto.CommonResponse;
 import com.appcenter.timepiece.config.SwaggerApiResponses;
-import com.appcenter.timepiece.dto.cover.CoverDataResponse;
 import com.appcenter.timepiece.dto.project.ProjectCreateUpdateRequest;
 import com.appcenter.timepiece.dto.project.TransferPrivilegeRequest;
 import com.appcenter.timepiece.service.ProjectService;
@@ -12,8 +11,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 
 @RequestMapping("")
@@ -164,7 +161,7 @@ public class ProjectController {
 
     @GetMapping("/v1/covers")
     @Operation(summary = "커버 이미지 메타데이터 조회", description = "")
-    public CommonResponse<List<CoverDataResponse>> join(@RequestParam(defaultValue = "0", required = false) Integer page,
+    public CommonResponse<?> join(@RequestParam(defaultValue = "0", required = false) Integer page,
                                                         @RequestParam(defaultValue = "10", required = false) Integer size) {
         return CommonResponse.success("조회 요청이 성공했습니다.", projectService.getCoverMetadata(page, size));
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #103

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

CommonPagingResponse 클래스를 만들어 쿼리 결과(data)를 한 번 더 감싸는 방식으로 구현했습니다.
추가된 페이징 관련 응답은 다음과 같습니다.
- currentPage
- pageSize
- totalCount
- totalPages

### 스크린샷 (선택)

![image](https://github.com/Your-Lie-in-April/server/assets/121238128/ba9d47a2-3178-46a0-ab62-2ce437627544)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

찾아보니 현재 커서와 함께 previous, next 커서를 조회하기 위한 링크를 제공하거나,
현재 추가한 4가지 정보 이외에도 다른 정보를 추가하는 경우도 있는 것 같습니다.

생각하셨을 때 더 필요하겠다 싶은 필드가 있다면 말씀해주세요. 그게 아니더라도 개선점이 보인다면 코멘트 부탁드립니다.
