### PR TITLE
일요일 스케줄 삭제되지 않는 버그 및 스케줄 조회 결과 닉네임 수정

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ScheduleService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ScheduleService.java
@@ -121,7 +121,7 @@ public class ScheduleService {
         LocalDateTime sundayOfWeek = calculateStartDay(LocalDateTime.of(condition, LocalTime.MIN));
 
         List<Schedule> schedules = scheduleRepository.findMemberWeekSchedule(memberProject.getId(), sundayOfWeek, sundayOfWeek.plusDays(7));
-        return new ScheduleWeekResponse(memberProject.getMember().getNickname(), schedules.stream()
+        return new ScheduleWeekResponse(memberProject.getNickname(), schedules.stream()
                 .map(schedule -> schedule.getStartTime().getDayOfWeek())
                 .distinct()
                 .map(dayOfWeek -> ScheduleDayResponse.of(dayOfWeek, schedules.stream()
@@ -193,6 +193,7 @@ public class ScheduleService {
 
         // todo: IndexOutOfBoundsException!! 발생 가능 -> Not Null, Not Empty하면 될 듯?
         LocalDateTime sundayOfWeek = calculateStartDay(request.getSchedule().get(0).getSchedule().get(0).getStartTime());
+        sundayOfWeek = sundayOfWeek.withHour(0).withMinute(0).withSecond(0).withNano(0);
         scheduleRepository.deleteMemberSchedulesBetween(memberProject.getId(), sundayOfWeek, sundayOfWeek.plusDays(7));
 
         List<Schedule> schedulesToSave = request.getSchedule().stream()

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ScheduleService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ScheduleService.java
@@ -193,7 +193,6 @@ public class ScheduleService {
 
         // todo: IndexOutOfBoundsException!! 발생 가능 -> Not Null, Not Empty하면 될 듯?
         LocalDateTime sundayOfWeek = calculateStartDay(request.getSchedule().get(0).getSchedule().get(0).getStartTime());
-//        sundayOfWeek = sundayOfWeek.withHour(0).withMinute(0).withSecond(0).withNano(0);
         scheduleRepository.deleteMemberSchedulesBetween(memberProject.getId(), sundayOfWeek, sundayOfWeek.plusDays(7));
 
         List<Schedule> schedulesToSave = request.getSchedule().stream()

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ScheduleService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ScheduleService.java
@@ -55,7 +55,7 @@ public class ScheduleService {
 
         List<Schedule> schedules = scheduleRepository.findMembersWeekSchedule(memberProjects.stream().map(MemberProject::getId).toList(), sundayOfWeek, sundayOfWeek.plusDays(7));
         return memberProjects.stream().map(memberProject ->
-                        new ScheduleWeekResponse(memberProject.getMember().getNickname(),
+                        new ScheduleWeekResponse(memberProject.getNickname(),
                                 schedules.stream()
                                         .filter(schedule -> schedule.getMemberProject().getId().equals(memberProject.getId()))
                                         .map(schedule -> schedule.getStartTime().getDayOfWeek())
@@ -83,7 +83,7 @@ public class ScheduleService {
         return memberProjects.stream()
                 .filter(memberProject -> !memberProject.getMember().getId().equals(((CustomUserDetails) userDetails).getId()))
                 .map(memberProject ->
-                        new ScheduleWeekResponse(memberProject.getMember().getNickname(),
+                        new ScheduleWeekResponse(memberProject.getNickname(),
                                 schedules.stream()
                                         .filter(schedule -> schedule.getMemberProject().getId().equals(memberProject.getId()))
                                         .map(schedule -> schedule.getStartTime().getDayOfWeek())


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #107 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

첫 주의 시작 날짜/시간(LocalDateTime)이 00시 00분 00초 00...로 지정될 수 있도록 수정했습니다.
+) 스케줄 조회 시 프로젝트 내 닉네임이 아닌 사용자 계정의 닉네임으로 조회되던 버그를 수정했습니다.

### 닉네임 관련 수정
전
<img width="850" alt="image" src="https://github.com/Your-Lie-in-April/server/assets/121238128/24bbc9a4-bc6b-4935-9dfb-e03404c16220">
후
![image](https://github.com/Your-Lie-in-April/server/assets/121238128/ef158814-19b8-4a01-8be9-6134803808c1)


