### PR TITLE
coverImageId null일 경우 프로젝트 생성되지 않던 현상 해결

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/project/ProjectCreateUpdateRequest.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/project/ProjectCreateUpdateRequest.java
@@ -17,7 +17,7 @@ import java.util.Set;
         requiredProperties = {
                 "title", "description", "startDate", "endDate",
                 "startTime", "endTime", "daysOfWeek",
-                "color", "coverId"})
+                "color", "coverImageId"})
 public class ProjectCreateUpdateRequest {
 
     @Schema(description = "제목", example = "프로젝트 제목입니다.")
@@ -41,8 +41,8 @@ public class ProjectCreateUpdateRequest {
     @Schema(description = "요일", example = "[\"MONDAY\", \"TUESDAY\", \"WEDNESDAY\", \"THURSDAY\", \"FRIDAY\", \"SATURDAY\"]")
     private Set<DayOfWeek> daysOfWeek;
 
-    @Schema(description = "배경색", example = "FFFFFF")
-    private String color;
+    @Schema(description = "배경색", example = "#FFFFFF")
+    private String color="#000000";
 
     @Schema(description = "커버 이미지 식별자",
             example = "10")

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
@@ -147,7 +147,12 @@ public class ProjectService {
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.MEMBER_NOT_FOUND));
-        Cover cover = coverRepository.findById(Long.valueOf(request.getCoverImageId())).orElse(null);;
+
+        Cover cover = null;
+        if (request.getCoverImageId() != null) {
+            cover = coverRepository.findById(Long.valueOf(request.getCoverImageId())).orElse(null);
+        }
+
         Project project = projectRepository.save(Project.of(request, cover));
         MemberProject memberProject = MemberProject.of(member, project);
         memberProject.grantPrivilege();


### PR DESCRIPTION
- coverImageId null일 경우 분기
- color, defaultValue=#000000 적용

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #112

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

coverImageId가 null일 경우 분기하여 해결했습니다.  
<img width="633" alt="image" src="https://github.com/Your-Lie-in-April/server/assets/121238128/3f8a9684-66ee-48a0-bc3b-a01134adf793">

color의 디폴트값을 설정했습니다.(#000000)
<img width="311" alt="스크린샷 2024-07-07 오후 6 23 46" src="https://github.com/Your-Lie-in-April/server/assets/121238128/e4ec53d2-ce0a-4ce4-acd9-bfdcfedc7b65">


