### PR TITLE
커버이미지 업로드 및 서빙 기능 구현

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/common/redis/RedisConfig.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/redis/RedisConfig.java
@@ -46,4 +46,13 @@ public class RedisConfig {
 
         return redisTemplate;
     }
+
+    @Bean
+    public RedisTemplate<String, byte[]> redisImageTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, byte[]> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        return template;
+    }
+
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/common/security/SecurityConfig.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/common/security/SecurityConfig.java
@@ -93,7 +93,8 @@ public class SecurityConfig {
             "/login/**", //oauth2 로그인창
             "/swagger-ui/**", //스웨거 명세
             "/v3/api-docs/**", //스웨거 명세
-            "/v1/invitation/{url}" //회원 초대(추가)
+            "/v1/invitation/{url}", //회원 초대(추가)
+            "/cover-image/**"
     };
 
     String[] PERMIT_USER_GET = {

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ImageController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ImageController.java
@@ -1,0 +1,45 @@
+package com.appcenter.timepiece.controller;
+
+import com.appcenter.timepiece.common.dto.CommonResponse;
+import com.appcenter.timepiece.service.ImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@RestController
+@RequestMapping
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping(value="/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> uploadImage(@RequestParam("id") String id, @RequestPart("file") MultipartFile file) {
+        try {
+            imageService.uploadImage(id, file);
+            return ResponseEntity.ok(CommonResponse.success("Image uploaded successfully", null));
+        } catch (IOException e) {
+            return ResponseEntity.status(500).body(CommonResponse.error("Failed to upload image", null));
+        }
+    }
+
+    @GetMapping("/cover-image/{id}")
+    public ResponseEntity<byte[]> getImage(@PathVariable String id) {
+        Optional<byte[]> imageData = imageService.getImage(id);
+        MediaType imageType = imageService.getImageType(id);
+        if (imageData.isPresent()) {
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + id + "\"")
+                    .contentType(imageType) // 이미지 타입에 맞춰 변경 가능
+                    .body(imageData.get());
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+}

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ImageController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ImageController.java
@@ -19,10 +19,10 @@ public class ImageController {
 
     private final ImageService imageService;
 
-    @PostMapping(value="/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<?> uploadImage(@RequestParam("id") String id, @RequestPart("file") MultipartFile file) {
+    @PostMapping(value="/v1/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> uploadImage(@RequestPart("file") MultipartFile file) {
         try {
-            imageService.uploadImage(id, file);
+            imageService.uploadImage(file);
             return ResponseEntity.ok(CommonResponse.success("Image uploaded successfully", null));
         } catch (IOException e) {
             return ResponseEntity.status(500).body(CommonResponse.error("Failed to upload image", null));
@@ -30,7 +30,7 @@ public class ImageController {
     }
 
     @GetMapping("/cover-image/{id}")
-    public ResponseEntity<byte[]> getImage(@PathVariable String id) {
+    public ResponseEntity<byte[]> getCoverImage(@PathVariable String id) {
         Optional<byte[]> imageData = imageService.getImage(id);
         MediaType imageType = imageService.getImageType(id);
         if (imageData.isPresent()) {

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
@@ -161,7 +161,7 @@ public class ProjectController {
 
     @GetMapping("/v1/covers")
     @Operation(summary = "커버 이미지 메타데이터 조회", description = "")
-    public CommonResponse<?> join(@RequestParam(defaultValue = "0", required = false) Integer page,
+    public CommonResponse<?> getCoverMetadata(@RequestParam(defaultValue = "0", required = false) Integer page,
                                                         @RequestParam(defaultValue = "10", required = false) Integer size) {
         return CommonResponse.success("조회 요청이 성공했습니다.", projectService.getCoverMetadata(page, size));
     }

--- a/timepiece/src/main/java/com/appcenter/timepiece/domain/Cover.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/domain/Cover.java
@@ -22,4 +22,12 @@ public class Cover {
 
     @OneToMany(mappedBy = "cover")
     private List<Project> projects = new ArrayList<>();
+
+    private Cover(String coverImageUrl) {
+        this.coverImageUrl = coverImageUrl;
+    }
+
+    public static Cover of(String coverImageUrl) {
+        return new Cover(coverImageUrl);
+    }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ImageService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ImageService.java
@@ -1,0 +1,38 @@
+package com.appcenter.timepiece.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final RedisTemplate<String, byte[]> redisImageTemplate;
+
+    public void uploadImage(String id, MultipartFile file) throws IOException {
+        byte[] imageData = file.getBytes();
+        redisImageTemplate.opsForValue().set("/cover-image/" + id, imageData);
+    }
+
+    public Optional<byte[]> getImage(String id) {
+        return Optional.ofNullable(redisImageTemplate.opsForValue().get(id));
+    }
+
+    public MediaType getImageType(String id) {
+        // 파일 확장자에 따라 이미지 타입을 설정합니다. 실제 구현 시 파일 메타데이터를 함께 저장하거나,
+        // 파일명에서 확장자를 추출하는 방식으로 구현할 수 있습니다.
+        if (id.endsWith(".png")) {
+            return MediaType.IMAGE_PNG;
+        } else if (id.endsWith(".gif")) {
+            return MediaType.IMAGE_GIF;
+        } else {
+            return MediaType.IMAGE_JPEG; // 기본값
+        }
+    }
+}

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ImageService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ImageService.java
@@ -1,6 +1,9 @@
 package com.appcenter.timepiece.service;
 
+import com.appcenter.timepiece.domain.Cover;
+import com.appcenter.timepiece.repository.CoverRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
@@ -8,16 +11,24 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class ImageService {
 
     private final RedisTemplate<String, byte[]> redisImageTemplate;
+    private final CoverRepository coverRepository;
 
-    public void uploadImage(String id, MultipartFile file) throws IOException {
+    @Value("${server.host}")
+    private String host;
+
+    public void uploadImage(MultipartFile file) throws IOException {
+        String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
+        Cover cover = Cover.of(host + "/cover-image/" + fileName);
         byte[] imageData = file.getBytes();
-        redisImageTemplate.opsForValue().set("/cover-image/" + id, imageData);
+        redisImageTemplate.opsForValue().set(fileName, imageData);
+        coverRepository.save(cover);
     }
 
     public Optional<byte[]> getImage(String id) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #115 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

커버 이미지 제공을 위한 
- redis 상에 저장한다. Byte[]
- 업로드 시 메타데이터는 바뀌지 않음.(수동)

### 추가 사항
[Java servlet - multipartfile Maximum upload size exceeded](https://stackoverflow.com/questions/54958189/spring-boot-multipart-file-maximum-upload-size-exception)
서블릿 기본 설정 상 1MB를 초과하는 파일은 업로드하지 못 합니다.
application.yml에 spring.servlet.multipart.max-<file/request>-size를 조절하여 서블릿 설정을 바꿀 수 있습니다.