### PR TITLE
fix: coverId 빈값 입력 시 프로젝트 수정 실패하던 버그

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
@@ -174,9 +174,13 @@ public class ProjectService {
     public void updateProject(Long projectId, ProjectCreateUpdateRequest request, UserDetails userDetails) {
         validateRequesterIsPrivileged(projectId, userDetails);
 
+        Cover cover = null;
+        if (request.getCoverImageId() != null && !request.getCoverImageId().isEmpty()) {
+            cover = coverRepository.findById(Long.valueOf(request.getCoverImageId())).orElse(null);
+        }
+
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.PROJECT_NOT_FOUND));
-        Cover cover = coverRepository.findById(Long.valueOf(request.getCoverImageId())).orElse(null);
 
         project.updateFrom(request, cover);
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #121 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

프로젝트 수정 시 입력값으로 coverImageId가 empty일 때, 요청이 실패하던 버그가 있었습니다.
프론트엔드 개발 유연성을 위해 서버에서 처리하여 사용자 경험이 정상적으로 흐를 수 있도록 수정했습니다.

### 스크린샷 (선택)

