### PR TITLE
Cover 엔티티 및 프로젝트 조회(썸네일, 상세) 응답 변경

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ImageController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ImageController.java
@@ -20,11 +20,12 @@ public class ImageController {
 
     private final ImageService imageService;
 
-    @Operation(summary = "이미지 등록(redis)", hidden = true)
+    @Operation(summary = "이미지 등록(redis)")
     @PostMapping(value="/v1/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<?> uploadImage(@RequestPart("file") MultipartFile file) {
+    public ResponseEntity<?> uploadImage(@RequestPart("thumbnail") MultipartFile thumbnail,
+                                         @RequestPart("coverImage") MultipartFile coverImage) {
         try {
-            imageService.uploadImage(file);
+            imageService.uploadImage(thumbnail, coverImage);
             return ResponseEntity.ok(CommonResponse.success("Image uploaded successfully", null));
         } catch (IOException e) {
             return ResponseEntity.status(500).body(CommonResponse.error("Failed to upload image", null));

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ImageController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ImageController.java
@@ -2,6 +2,7 @@ package com.appcenter.timepiece.controller;
 
 import com.appcenter.timepiece.common.dto.CommonResponse;
 import com.appcenter.timepiece.service.ImageService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -19,6 +20,7 @@ public class ImageController {
 
     private final ImageService imageService;
 
+    @Operation(summary = "이미지 등록(redis)", hidden = true)
     @PostMapping(value="/v1/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<?> uploadImage(@RequestPart("file") MultipartFile file) {
         try {
@@ -29,6 +31,7 @@ public class ImageController {
         }
     }
 
+    @Operation(summary = "이미지 조회(Get)", hidden = true)
     @GetMapping("/cover-image/{id}")
     public ResponseEntity<byte[]> getCoverImage(@PathVariable String id) {
         Optional<byte[]> imageData = imageService.getImage(id);

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
@@ -57,6 +57,7 @@ public class ProjectController {
     }
 
     @GetMapping("/v1/projects/members/{memberId}/{keyword}")
+    @Operation(summary = "프로젝트 검색", description = "")
     public ResponseEntity<CommonResponse<?>> searchProjects(@RequestParam(defaultValue = "0", required = false) Integer page,
                                                             @RequestParam(defaultValue = "6", required = false) Integer size,
                                                             @PathVariable Long memberId,

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/ProjectController.java
@@ -26,7 +26,7 @@ public class ProjectController {
      * DB에 저장된 모든 프로젝트를 조회하여 ProjectResponse 타입의 List를 리턴합니다.
      */
     @GetMapping("/v1/projects/all")
-    @Operation(summary = "프로젝트 전체 조회", description = "")
+    @Operation(summary = "프로젝트 전체 조회", description = "Just for test", deprecated = true)
     public ResponseEntity<CommonResponse<?>> findAllForTest() {
         return ResponseEntity.ok().body(CommonResponse.success("전체 프로젝트 조회 성공", projectService.findAll()));
     }

--- a/timepiece/src/main/java/com/appcenter/timepiece/domain/Cover.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/domain/Cover.java
@@ -17,17 +17,21 @@ public class Cover {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "thumbnail_url", columnDefinition = "TEXT")
+    private String thumbnailUrl;
+
     @Column(name = "cover_image_url", columnDefinition = "TEXT")
     private String coverImageUrl;
 
     @OneToMany(mappedBy = "cover")
     private List<Project> projects = new ArrayList<>();
 
-    private Cover(String coverImageUrl) {
+    private Cover(String thumbnailUrl, String coverImageUrl) {
+        this.thumbnailUrl = thumbnailUrl;
         this.coverImageUrl = coverImageUrl;
     }
 
-    public static Cover of(String coverImageUrl) {
-        return new Cover(coverImageUrl);
+    public static Cover of(String thumbnailUrl, String coverImageUrl) {
+        return new Cover(thumbnailUrl, coverImageUrl);
     }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/cover/CoverDataResponse.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/cover/CoverDataResponse.java
@@ -17,6 +17,6 @@ public class CoverDataResponse {
     }
 
     public static CoverDataResponse of(Cover cover) {
-        return new CoverDataResponse(cover.getId() + 10, cover.getCoverImageUrl());
+        return new CoverDataResponse(cover.getId(), cover.getThumbnailUrl());
     }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/project/ProjectResponse.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/project/ProjectResponse.java
@@ -36,17 +36,19 @@ public class ProjectResponse {
 
     @Getter
     private static class CoverInfo {
-        private Long coverId;
+        private Long id;
+        private String thumbnailUrl;
         private String coverImageUrl;
 
-        private CoverInfo(Long coverId, String coverImageUrl) {
-            this.coverId = coverId;
+        public CoverInfo(Long thumbnailId, String thumbnailUrl, String coverImageUrl) {
+            this.id = thumbnailId;
+            this.thumbnailUrl = thumbnailUrl;
             this.coverImageUrl = coverImageUrl;
         }
 
         public static CoverInfo of(Cover cover) {
             if (cover == null) return null;
-            return new CoverInfo(cover.getId(), cover.getCoverImageUrl());
+            return new CoverInfo(cover.getId(), cover.getThumbnailUrl(), cover.getCoverImageUrl());
         }
 
     }

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/project/ProjectResponse.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/project/ProjectResponse.java
@@ -1,5 +1,6 @@
 package com.appcenter.timepiece.dto.project;
 
+import com.appcenter.timepiece.domain.Cover;
 import com.appcenter.timepiece.domain.Project;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -29,16 +30,33 @@ public class ProjectResponse {
 
     private Set<DayOfWeek> daysOfWeek;
 
-    private String coverImageUrl;
+    private CoverInfo coverInfo;
 
     private String color;
+
+    @Getter
+    private static class CoverInfo {
+        private Long coverId;
+        private String coverImageUrl;
+
+        private CoverInfo(Long coverId, String coverImageUrl) {
+            this.coverId = coverId;
+            this.coverImageUrl = coverImageUrl;
+        }
+
+        public static CoverInfo of(Cover cover) {
+            if (cover == null) return null;
+            return new CoverInfo(cover.getId(), cover.getCoverImageUrl());
+        }
+
+    }
 
     @Builder(access = AccessLevel.PRIVATE)
     private ProjectResponse(Long projectId, String title, String description,
                             LocalDate startDate, LocalDate endDate,
                             LocalTime startTime, LocalTime endTime,
                             Set<DayOfWeek> daysOfWeek,
-                            String coverImageUrl, String color) {
+                            CoverInfo coverInfo, String color) {
         this.projectId = projectId;
         this.title = title;
         this.description = description;
@@ -47,11 +65,11 @@ public class ProjectResponse {
         this.startTime = startTime;
         this.endTime = endTime;
         this.daysOfWeek = daysOfWeek;
-        this.coverImageUrl = coverImageUrl;
+        this.coverInfo = coverInfo;
         this.color = color;
     }
 
-    public static ProjectResponse of(Project project, String coverImageUrl) {
+    public static ProjectResponse of(Project project, Cover cover) {
         return ProjectResponse.builder()
                 .projectId(project.getId())
                 .title(project.getTitle())
@@ -61,7 +79,7 @@ public class ProjectResponse {
                 .startTime(project.getStartTime())
                 .endTime(project.getEndTime())
                 .daysOfWeek(project.getDaysOfWeek())
-                .coverImageUrl(coverImageUrl)
+                .coverInfo(CoverInfo.of(cover))
                 .color(project.getColor())
                 .build();
     }

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/project/ProjectThumbnailResponse.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/project/ProjectThumbnailResponse.java
@@ -16,25 +16,25 @@ public class ProjectThumbnailResponse {
 
     private String color;
 
-    private String coverImageUrl;
+    private String thumbnailUrl;
 
     @Builder(access = AccessLevel.PRIVATE)
     private ProjectThumbnailResponse(Long projectId, String title, String description,
-                                     String color, String coverImageUrl) {
+                                     String color, String thumbnailUrl) {
         this.projectId = projectId;
         this.title = title;
         this.description = description;
         this.color = color;
-        this.coverImageUrl = coverImageUrl;
+        this.thumbnailUrl = thumbnailUrl;
     }
 
-    public static ProjectThumbnailResponse of(Project project, String coverImageUrl) {
+    public static ProjectThumbnailResponse of(Project project, String thumbnailUrl) {
         return ProjectThumbnailResponse.builder()
                 .projectId(project.getId())
                 .title(project.getTitle())
                 .description(project.getDescription())
                 .color(project.getColor())
-                .coverImageUrl(coverImageUrl)
+                .thumbnailUrl(thumbnailUrl)
                 .build();
     }
 }

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ImageService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ImageService.java
@@ -23,11 +23,14 @@ public class ImageService {
     @Value("${server.host}")
     private String host;
 
-    public void uploadImage(MultipartFile file) throws IOException {
-        String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
-        Cover cover = Cover.of(host + "/cover-image/" + fileName);
-        byte[] imageData = file.getBytes();
-        redisImageTemplate.opsForValue().set(fileName, imageData);
+    public void uploadImage(MultipartFile thumbnail, MultipartFile coverImage) throws IOException {
+        String thumbnailName = UUID.randomUUID() + "_" + thumbnail.getOriginalFilename();
+        String coverName = UUID.randomUUID() + "_" + coverImage.getOriginalFilename();
+        Cover cover = Cover.of(host + "/cover-image/" + thumbnailName, host + "/cover-image/" + coverName);
+        byte[] thumbnailImageData = thumbnail.getBytes();
+        byte[] coverImageData = coverImage.getBytes();
+        redisImageTemplate.opsForValue().set(thumbnailName, thumbnailImageData);
+        redisImageTemplate.opsForValue().set(coverName, coverImageData);
         coverRepository.save(cover);
     }
 

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
@@ -42,10 +42,10 @@ public class ProjectService {
     private final MemberProjectRepository memberProjectRepository;
     private final NotificationService notificationService;
 
+    @Transactional(readOnly = true)
     public List<ProjectResponse> findAll() {
         return projectRepository.findAllWithCover().stream().map(p ->
-                ProjectResponse.of(p,
-                        ((p.getCover() == null) ? null : p.getCover().getCoverImageUrl()))).toList();
+                ProjectResponse.of(p, p.getCover())).toList();
     }
 
     @Transactional(readOnly = true)
@@ -53,8 +53,7 @@ public class ProjectService {
         validateMemberIsInProject(projectId, userDetails);
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new NotFoundElementException(ExceptionMessage.PROJECT_NOT_FOUND));
-        Cover cover = project.getCover();
-        return ProjectResponse.of(project, (cover == null) ? null : cover.getCoverImageUrl());
+        return ProjectResponse.of(project, project.getCover());
     }
 
     /**

--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ProjectService.java
@@ -68,7 +68,7 @@ public class ProjectService {
         List<MemberProject> projects = projectPage.getContent();
         List<ProjectThumbnailResponse> projectThumbnailResponses = projects.stream()
                 .map(MemberProject::getProject)
-                .map(p -> ProjectThumbnailResponse.of(p, ((p.getCover() == null) ? null : p.getCover().getCoverImageUrl()))).toList();
+                .map(p -> ProjectThumbnailResponse.of(p, ((p.getCover() == null) ? null : p.getCover().getThumbnailUrl()))).toList();
 
         return new CommonPagingResponse<>(page, size, projectPage.getTotalElements(), projectPage.getTotalPages(), projectThumbnailResponses);
     }
@@ -112,7 +112,7 @@ public class ProjectService {
         Page<Project> projectPage = projectRepository.searchProjects(memberId, keyword, isStored, pageable);
         List<Project> projects = projectPage.getContent();
         List<ProjectThumbnailResponse> projectThumbnailResponses = projects.stream()
-                .map(p -> ProjectThumbnailResponse.of(p, ((p.getCover() == null) ? null : p.getCover().getCoverImageUrl()))).toList();
+                .map(p -> ProjectThumbnailResponse.of(p, ((p.getCover() == null) ? null : p.getCover().getThumbnailUrl()))).toList();
         return new CommonPagingResponse<>(page, size, projectPage.getTotalElements(), projectPage.getTotalPages(), projectThumbnailResponses);
 
     }
@@ -309,7 +309,7 @@ public class ProjectService {
         List<Project> projects = projectPage.getContent();
 
         List<ProjectThumbnailResponse> projectThumbnailResponses = projects.stream().map(p ->
-                ProjectThumbnailResponse.of(p, ((p.getCover() == null) ? null : p.getCover().getCoverImageUrl()))).toList();
+                ProjectThumbnailResponse.of(p, ((p.getCover() == null) ? null : p.getCover().getThumbnailUrl()))).toList();
         return new CommonPagingResponse<>(page, size, projectPage.getTotalElements(), projectPage.getTotalPages(), projectThumbnailResponses);
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #124 
close #125 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

**Cover 엔티티 변경**
기존 Cover 엔티티의 문제는 썸네일 이미지와, 매칭되는 커버 이미지 간 매핑 정보를 어디에서도 알 수 없다는 것입니다.
속성이 다른 두 개의 이미지를 구분하는 필드없이 같은 테이블에 모아놨기 때문에, 관련 매핑 로직은 코드 상에 하드코딩 될 수 밖에 없었습니다.
이를 해결하고자 Cover 엔티티를 변경했습니다.
```
public class Cover  {
   ,,,
   // 새 속성 추가 
    @Column(name = "thumbnail_url", columnDefinition = "TEXT")
    private String thumbnailUrl;
   ... 
} 
```

**프로젝트 상세 조회**
응답(ProjectResponse), coverImageUrl -> CoverInfo (VO 객체)로 변경됐습니다.
```
private static class CoverInfo {
    ... Long id;
    ... String thumbnailUrl;
    ... String coverImageUrl
}
```
**프로젝트 목록 조회**
- 소속 프로젝트 조회
- 보관 프로젝트 조회
- 프로젝트 검색

위 세 항목의 응답 필드명이 변경됐습니다.
```
coverImageUrl -> thumbnailUrl
```

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/fea48d6e-53c9-4fae-9da9-ebe2f8d31243)

![image](https://github.com/user-attachments/assets/8d699f84-a2da-456f-aecf-6775704508c4)
