### PR TITLE
자정(00시) Schedule 생성 허용

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/service/ScheduleService.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/service/ScheduleService.java
@@ -316,10 +316,7 @@ public class ScheduleService {
         if (dates.get(0).isBefore(project.getStartDate()) || dates.get(dates.size() - 1).isAfter(project.getEndDate())) {
             throw new IllegalArgumentException(ExceptionMessage.INVALID_PROJECT_PERIOD.getMessage());
         }
-
-
     }
-
 
     /**
      * ScheduleCreateUpdateRequest 일(Day) 단위 검증 <br>
@@ -370,7 +367,6 @@ public class ScheduleService {
         }
     }
 
-
     /**
      * ScheduleCreateUpdateRequest ScheduleDto 단위 검증 <br>
      * 수행목록 <br>
@@ -403,20 +399,9 @@ public class ScheduleService {
         }
     }
 
-//    private void validateTimeSequencePerSchedule(LocalTime startTime, LocalTime endTime) {
-//        if (startTime.isAfter(endTime)) {
-//            throw new IllegalArgumentException(ExceptionMessage.INVALID_TIME_SEQUENCE.getMessage());
-//        }
-//    }
-
-//    private void validateIsSameDayPerSchedule(LocalDate startDate, LocalDate endDate) {
-//        if (!Objects.equals(startDate, endDate)) {
-//            throw new IllegalArgumentException(ExceptionMessage.IS_NOT_SAME_DAY.getMessage());
-//        }
-//    }
-
     /**
-     *
+     * 스케줄 생성 요청의 endTime이 자정일 경우, endDate가 startDate 보다 하루 이후여야 합니다.
+     * 자정이 아닐 경우, 동일 날짜이고 startTime < endTime을 만족해야 합니다.
      * @param startDate
      * @param startTime
      * @param endDate


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #137

## 📝작업 내용

자정(00시)를 endTime으로 스케줄 생성이 가능토록 검증 스케줄 생성 DTO 로직을 수정했습니다.

### 스크린샷 (선택)

<img width="1072" alt="image" src="https://github.com/user-attachments/assets/9b1b74ce-dd07-439b-87a7-6d8ec8b3a05a">

<img width="1059" alt="스크린샷 2024-08-10 오후 6 02 50" src="https://github.com/user-attachments/assets/bca035ed-35e3-42b5-9e47-b8b8f31eca22">

<img width="1065" alt="스크린샷 2024-08-10 오후 6 03 08" src="https://github.com/user-attachments/assets/bb05616f-a576-4f44-89ae-57aacb106f6e">

## 💬리뷰 요구사항(선택)
로컬에서 테스트는 해봤지만 검증 로직 다시 한 번 확인부탁드립니다.