### PR TITLE
SSE Last-Event-Id 개선

### DIFF
--- a/timepiece/src/main/java/com/appcenter/timepiece/config/LoggingAspect.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/config/LoggingAspect.java
@@ -1,5 +1,6 @@
 package com.appcenter.timepiece.config;
 
+import java.lang.reflect.Method;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
@@ -7,8 +8,6 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.stereotype.Component;
-
-import java.lang.reflect.Method;
 
 @Aspect
 @Component
@@ -28,9 +27,13 @@ public class LoggingAspect {
 
         // 파라미터 받아오기
         Object[] args = proceedingJoinPoint.getArgs();
-        if (args.length == 0) log.info("no parameter");
+        if (args.length == 0) {
+            log.info("no parameter");
+        }
         for (Object arg : args) {
-            log.info("parameter = {}, {}", arg.getClass().getSimpleName(), arg.toString());
+            if (arg != null) {
+                log.info("parameter = {}, {}", arg.getClass().getSimpleName(), arg.toString());
+            }
         }
 
         // proceed()를 호출하여 실제 메서드 실행

--- a/timepiece/src/main/java/com/appcenter/timepiece/controller/NotificationController.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/controller/NotificationController.java
@@ -4,15 +4,20 @@ import com.appcenter.timepiece.common.dto.CommonResponse;
 import com.appcenter.timepiece.config.SwaggerApiResponses;
 import com.appcenter.timepiece.service.NotificationService;
 import io.swagger.v3.oas.annotations.Operation;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-
-import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("")
@@ -25,28 +30,32 @@ public class NotificationController {
     @Operation(summary = "SSE Connect", description = "SSE 커넥션을 맺습니다.")
     @GetMapping(value = "/v1/sse/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter subscribe(@AuthenticationPrincipal UserDetails userDetails,
-                                @RequestParam(required = false, defaultValue = "") String lastEventId) {
+                                @RequestParam(required = false) Long lastEventId,
+                                @RequestParam(required = false) Long projectId) {
         log.info("Last-Event-Id: {}", lastEventId);
         // todo: lastEventId -> 유실된 Message 전송
-        return notificationService.subscribe(userDetails);
+        return notificationService.subscribe(userDetails, lastEventId, projectId);
     }
 
     @Operation(summary = "이전 알림 조회", description = "DB에 저장된 알림을 조회합니다.")
     @GetMapping(value = "/v1/notifications")
-    public CommonResponse<?> getNotifications(@RequestParam(defaultValue = "#{T(java.time.LocalDateTime).now()}", required = false) LocalDateTime cursor,
-                                              @RequestParam(defaultValue = "false", required = false) Boolean isChecked,
-                                       @RequestParam(defaultValue = "12", required = false) Integer size,
-                                       @AuthenticationPrincipal UserDetails userDetails) {
-        return CommonResponse.success("알림 조회에 성공했습니다.",notificationService.getNotifications(cursor, isChecked, size, userDetails));
+    public CommonResponse<?> getNotifications(
+            @RequestParam(defaultValue = "#{T(java.time.LocalDateTime).now()}", required = false) LocalDateTime cursor,
+            @RequestParam(defaultValue = "false", required = false) Boolean isChecked,
+            @RequestParam(defaultValue = "12", required = false) Integer size,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        return CommonResponse.success("알림 조회에 성공했습니다.",
+                notificationService.getNotifications(cursor, isChecked, size, userDetails));
     }
 
     @Operation(summary = "(프로젝트 내)이전 알림 조회", description = "DB에 저장된 특정 프로젝트의 알림을 조회합니다.")
     @GetMapping(value = "/v1/projects/{projectId}/notifications")
-    public CommonResponse<?> getNotificationsInProject(@RequestParam(defaultValue = "#{T(java.time.LocalDateTime).now()}", required = false) LocalDateTime cursor,
-                                                       @RequestParam(defaultValue = "false", required = false) Boolean isChecked,
-                                                       @RequestParam(defaultValue = "12", required = false) Integer size,
-                                                       @PathVariable Long projectId,
-                                                       @AuthenticationPrincipal UserDetails userDetails) {
+    public CommonResponse<?> getNotificationsInProject(
+            @RequestParam(defaultValue = "#{T(java.time.LocalDateTime).now()}", required = false) LocalDateTime cursor,
+            @RequestParam(defaultValue = "false", required = false) Boolean isChecked,
+            @RequestParam(defaultValue = "12", required = false) Integer size,
+            @PathVariable Long projectId,
+            @AuthenticationPrincipal UserDetails userDetails) {
         return CommonResponse.success("알림 조회에 성공했습니다.",
                 notificationService.getNotificationsInProject(projectId, cursor, isChecked, size, userDetails));
     }
@@ -62,7 +71,7 @@ public class NotificationController {
     @Operation(summary = "알림 읽음 처리", description = "notificationId에 해당하는 알림을 읽음 처리 합니다.")
     @PatchMapping(value = "/v1/projects/notifications/{notificationId}")
     public CommonResponse<?> check(@PathVariable Long notificationId,
-                                       @AuthenticationPrincipal UserDetails userDetails) {
+                                   @AuthenticationPrincipal UserDetails userDetails) {
         return CommonResponse.success("알림 읽을 처리에 성공했습니다.",
                 notificationService.check(notificationId, userDetails));
     }

--- a/timepiece/src/main/java/com/appcenter/timepiece/repository/NotificationRepositoryCustom.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/repository/NotificationRepositoryCustom.java
@@ -1,12 +1,18 @@
 package com.appcenter.timepiece.repository;
 
 import com.appcenter.timepiece.domain.Notification;
-
 import java.time.LocalDateTime;
 import java.util.List;
 
 
 public interface NotificationRepositoryCustom {
-    List<Notification> findAllByTimestampAfter(Long receiverId, LocalDateTime timestamp, Boolean isChecked, int pageSize);
-    List<Notification> findAllByTimestampAfter(Long receiverId, Long projectId, LocalDateTime timestamp, Boolean isChecked, int pageSize);
+    List<Notification> findAllByTimestampAfter(Long receiverId, LocalDateTime timestamp, Boolean isChecked,
+                                               int pageSize);
+
+    List<Notification> findAllByTimestampAfter(Long receiverId, Long projectId, LocalDateTime timestamp,
+                                               Boolean isChecked, int pageSize);
+
+    List<Notification> findAllByReceiverLargerThanNotificationId(Long receiverId, Long notificationId);
+
+    List<Notification> findAllByReceiverLargerThanNotificationId(Long receiverId, Long projectId, Long notificationId);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close #152 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

그동안 SSE 재연결이 이뤄지는 동안 발생하는 알림이 유실되던 문제가 있었습니다.
클라이언트 측에서 마지막으로 받은 알림ID를 관리하고, 재연결 시도 때 함께 요청합니다.
재연결 후 클라이언트가 받지못한 알림을 재전송합니다.

### 스크린샷 (선택)
![스크린샷 2025-02-02 오후 4 48 36](https://github.com/user-attachments/assets/31471d75-96cc-43df-8dfb-f6a3f282c914)
![스크린샷 2025-02-02 오후 4 48 38](https://github.com/user-attachments/assets/d2dcc499-8808-49ea-86a4-d227eced4ef8)


