### PR TITLE
Controller 테스트 코드 구현

### DIFF
--- a/timepiece/build.gradle
+++ b/timepiece/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
@@ -57,6 +56,8 @@ dependencies {
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 
     //Querydsl 추가
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
@@ -64,6 +65,22 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+    main.java.srcDir querydslDir
+}
+
+tasks.named('compileJava') {
+    options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+
+tasks.named('clean') {
+    doLast {
+        file(querydslDir).deleteDir()
+    }
 }
 
 tasks.named('test') {

--- a/timepiece/src/main/java/com/appcenter/timepiece/TimepieceApplication.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/TimepieceApplication.java
@@ -7,11 +7,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableConfigurationProperties(CorsProperties.class)
 @OpenAPIDefinition(servers = {@Server(url = "/", description = "Default Server url")})
-@EnableJpaAuditing
 @EnableAspectJAutoProxy
 @SpringBootApplication
 public class TimepieceApplication {

--- a/timepiece/src/main/java/com/appcenter/timepiece/config/JpaAuditingConfig.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.appcenter.timepiece.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+}

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/member/MemberResponse.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/member/MemberResponse.java
@@ -21,7 +21,7 @@ public class MemberResponse {
 
     private Boolean isPrivileged;
 
-    @Builder(access = AccessLevel.PRIVATE)
+    @Builder(access = AccessLevel.PUBLIC)
     private MemberResponse(Long memberId, String email, String nickname, String state, String profileImageUrl, Boolean isPrivileged) {
         this.memberId = memberId;
         this.email = email;

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/member/TokenResponse.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/member/TokenResponse.java
@@ -1,10 +1,13 @@
 package com.appcenter.timepiece.dto.member;
 
 
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TokenResponse {
 
     private String refreshToken;

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/project/InvitationLinkResponse.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/project/InvitationLinkResponse.java
@@ -1,6 +1,7 @@
 package com.appcenter.timepiece.dto.project;
 
 import com.appcenter.timepiece.domain.Project;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,6 +12,7 @@ public class InvitationLinkResponse {
     String title;
     String link;
 
+    @Builder
     private InvitationLinkResponse(Long projectId, String title, String link) {
         this.projectId = projectId;
         this.title = title;

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/project/InvitationResponse.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/project/InvitationResponse.java
@@ -1,6 +1,8 @@
 package com.appcenter.timepiece.dto.project;
 
 import com.appcenter.timepiece.domain.Project;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,6 +15,7 @@ public class InvitationResponse {
     String invitator;
     Boolean isExpired;
 
+    @Builder(access = AccessLevel.PUBLIC)
     private InvitationResponse(String title, String invitator, Boolean isExpired) {
         this.title = title;
         this.invitator = invitator;

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/project/PinProjectResponse.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/project/PinProjectResponse.java
@@ -39,7 +39,7 @@ public class PinProjectResponse {
 
     private List<ScheduleWeekResponse> schedule;
 
-    @Builder(access = AccessLevel.PRIVATE)
+    @Builder(access = AccessLevel.PUBLIC)
     private PinProjectResponse(Long projectId, String title, String description, LocalDate startDate, LocalDate endDate,
                                LocalTime startTime, LocalTime endTime,
                                Set<DayOfWeek> daysOfWeek,

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/project/ProjectResponse.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/project/ProjectResponse.java
@@ -40,6 +40,7 @@ public class ProjectResponse {
         private String thumbnailUrl;
         private String coverImageUrl;
 
+        @Builder(access = AccessLevel.PUBLIC)
         public CoverInfo(Long thumbnailId, String thumbnailUrl, String coverImageUrl) {
             this.id = thumbnailId;
             this.thumbnailUrl = thumbnailUrl;
@@ -53,7 +54,7 @@ public class ProjectResponse {
 
     }
 
-    @Builder(access = AccessLevel.PRIVATE)
+    @Builder(access = AccessLevel.PUBLIC)
     private ProjectResponse(Long projectId, String title, String description,
                             LocalDate startDate, LocalDate endDate,
                             LocalTime startTime, LocalTime endTime,

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/project/ProjectThumbnailResponse.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/project/ProjectThumbnailResponse.java
@@ -18,7 +18,7 @@ public class ProjectThumbnailResponse {
 
     private String thumbnailUrl;
 
-    @Builder(access = AccessLevel.PRIVATE)
+    @Builder(access = AccessLevel.PUBLIC)
     private ProjectThumbnailResponse(Long projectId, String title, String description,
                                      String color, String thumbnailUrl) {
         this.projectId = projectId;

--- a/timepiece/src/main/java/com/appcenter/timepiece/dto/project/TransferPrivilegeRequest.java
+++ b/timepiece/src/main/java/com/appcenter/timepiece/dto/project/TransferPrivilegeRequest.java
@@ -16,4 +16,8 @@ public class TransferPrivilegeRequest {
     public String toString() {
         return "toMemberId = " + toMemberId;
     }
+
+    public TransferPrivilegeRequest(Long toMemberId) {
+        this.toMemberId = toMemberId;
+    }
 }

--- a/timepiece/src/test/java/com/appcenter/timepiece/config/TestSecurityConfig.java
+++ b/timepiece/src/test/java/com/appcenter/timepiece/config/TestSecurityConfig.java
@@ -1,0 +1,47 @@
+package com.appcenter.timepiece.config;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Collections;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+public class TestSecurityConfig {
+    @Bean
+    public SecurityFilterChain configure(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity
+                .httpBasic(HttpBasicConfigurer::disable)
+                .csrf(CsrfConfigurer::disable)
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorize -> authorize
+                        .anyRequest().permitAll()
+                )
+                .exceptionHandling(authentication -> authentication
+                        .authenticationEntryPoint((request, response, exception) ->
+                                response.sendError(HttpServletResponse.SC_UNAUTHORIZED))
+                        .accessDeniedHandler((request, response, exception) ->
+                                response.sendError(HttpServletResponse.SC_FORBIDDEN))
+                );
+
+        return httpSecurity.build();
+    }
+
+    // 필요시 테스트용 인증 관리자 추가
+    @Bean
+    public AuthenticationManager authenticationManager() {
+        return authentication -> {
+            // 테스트용 인증 로직 (항상 인증 성공 또는 특정 조건에 따라 인증)
+            return new UsernamePasswordAuthenticationToken("testuser", "password",
+                    Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER")));
+        };
+    }
+}

--- a/timepiece/src/test/java/com/appcenter/timepiece/controller/AuthControllerTest.java
+++ b/timepiece/src/test/java/com/appcenter/timepiece/controller/AuthControllerTest.java
@@ -1,0 +1,55 @@
+package com.appcenter.timepiece.controller;
+
+import com.appcenter.timepiece.config.TestSecurityConfig;
+import com.appcenter.timepiece.dto.member.TokenResponse;
+import com.appcenter.timepiece.service.AuthService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = AuthController.class)
+@Import(TestSecurityConfig.class)
+public class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    @Test
+    @DisplayName("토큰 재발급 요청이 성공적으로 처리되어야 한다")
+    void reissueAccessTokenTest() throws Exception {
+        // Given
+        String newAccessToken = "new.access.token";
+        String newRefreshToken = "new.refresh.token";
+        TokenResponse response = TokenResponse.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
+                .build();
+        given(authService.reissueAccessToken(any())).willReturn(response);
+
+        // When & Then
+        mockMvc.perform(post("/v1/auth/reissue")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("토큰 재발급 성공"))
+                .andExpect(jsonPath("$.data.accessToken").value(newAccessToken))
+                .andExpect(jsonPath("$.data.refreshToken").value(newRefreshToken));
+    }
+
+}

--- a/timepiece/src/test/java/com/appcenter/timepiece/controller/ImageControllerTest.java
+++ b/timepiece/src/test/java/com/appcenter/timepiece/controller/ImageControllerTest.java
@@ -1,0 +1,131 @@
+package com.appcenter.timepiece.controller;
+
+import com.appcenter.timepiece.config.TestSecurityConfig;
+import com.appcenter.timepiece.service.ImageService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ImageController.class)
+@Import(TestSecurityConfig.class)
+public class ImageControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ImageService imageService;
+
+    @Test
+    @DisplayName("이미지 업로드가 성공적으로 처리되어야 한다")
+    void uploadImageSuccessTest() throws Exception {
+        // Given
+        MockMultipartFile thumbnail = new MockMultipartFile(
+                "thumbnail",
+                "thumbnail.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                "thumbnail content".getBytes()
+        );
+
+        MockMultipartFile coverImage = new MockMultipartFile(
+                "coverImage",
+                "cover.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                "cover content".getBytes()
+        );
+
+        // When & Then
+        mockMvc.perform(multipart("/v1/image")
+                        .file(thumbnail)
+                        .file(coverImage)
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("이미지를 성공적으로 업로드하였습니다."));
+    }
+
+    @Test
+    @DisplayName("이미지 업로드 실패 시 에러 응답을 반환해야 한다")
+    void uploadImageFailureTest() throws Exception {
+        // Given
+        MockMultipartFile thumbnail = new MockMultipartFile(
+                "thumbnail",
+                "thumbnail.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                "thumbnail content".getBytes()
+        );
+
+        MockMultipartFile coverImage = new MockMultipartFile(
+                "coverImage",
+                "cover.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                "cover content".getBytes()
+        );
+
+        willThrow(new java.io.IOException("Upload failed")).given(imageService).uploadImage(any(), any());
+
+        // When & Then
+        mockMvc.perform(multipart("/v1/image")
+                        .file(thumbnail)
+                        .file(coverImage)
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("이미지 업로드에 실패했습니다."));
+    }
+
+    @Test
+    @DisplayName("커버 이미지 조회가 성공적으로 처리되어야 한다")
+    void getCoverImageSuccessTest() throws Exception {
+        // Given
+        String imageId = "123";
+        byte[] imageData = "image content".getBytes();
+
+        given(imageService.getImage(eq(imageId))).willReturn(Optional.of(imageData));
+        given(imageService.getImageType(eq(imageId))).willReturn(MediaType.IMAGE_JPEG);
+
+        // When & Then
+        mockMvc.perform(get("/cover-image/{id}", imageId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "inline;"))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.IMAGE_JPEG))
+                .andExpect(content().bytes(imageData));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이미지 조회 시 404 응답을 반환해야 한다")
+    void getCoverImageNotFoundTest() throws Exception {
+        // Given
+        String imageId = "nonexistent";
+
+        given(imageService.getImage(eq(imageId))).willReturn(Optional.empty());
+
+        // When & Then
+        mockMvc.perform(get("/cover-image/{id}", imageId))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+}

--- a/timepiece/src/test/java/com/appcenter/timepiece/controller/MemberControllerTest.java
+++ b/timepiece/src/test/java/com/appcenter/timepiece/controller/MemberControllerTest.java
@@ -1,0 +1,155 @@
+package com.appcenter.timepiece.controller;
+
+import com.appcenter.timepiece.common.security.SecurityConfig;
+import com.appcenter.timepiece.config.TestSecurityConfig;
+import com.appcenter.timepiece.domain.Member;
+import com.appcenter.timepiece.dto.member.MemberResponse;
+import com.appcenter.timepiece.service.MemberService;
+import com.appcenter.timepiece.service.ProjectService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemberController.class)
+@Import(TestSecurityConfig.class)
+public class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MemberService memberService;
+
+    @MockBean
+    private ProjectService projectService;
+
+    @Test
+    @DisplayName("모든 멤버 조회가 성공적으로 처리되어야 한다")
+    void allUsersTest() throws Exception {
+        // Given
+        Member member = new Member(null, "namu", "namu2024@gmail.com", "", "", List.of("ROLE_USER"));
+        List<MemberResponse> members = List.of(MemberResponse.from(member));
+        given(memberService.getAllMember()).willReturn(members);
+
+        // When & Then
+        mockMvc.perform(get("/v1/members/all"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("(테스트)멤버 조회 성공"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data[0].memberId").hasJsonPath())
+                .andExpect(jsonPath("$.data[0].nickname").value("namu"));
+    }
+
+    @Test
+    @DisplayName("특정 멤버 정보 조회가 성공적으로 처리되어야 한다")
+    void memberInfoTest() throws Exception {
+        // Given
+        Long memberId = 1L;
+        Member member = new Member(null, "namu", "namu2024@gmail.com", "", "", List.of("ROLE_USER"));
+
+        MemberResponse memberInfo =  MemberResponse.from(member);
+
+        given(memberService.getMemberInfo(eq(memberId))).willReturn(memberInfo);
+
+        // When & Then
+        mockMvc.perform(get("/v1/members/{memberId}", memberId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("멤버 정보 조회 성공"))
+                .andExpect(jsonPath("$.data.memberId").hasJsonPath())
+                .andExpect(jsonPath("$.data.nickname").value("namu"));
+    }
+
+    @Test
+    @DisplayName("닉네임 재설정 V2 요청이 성공적으로 처리되어야 한다")
+    void editUserNickname2Test() throws Exception {
+        // Given
+        Long projectId = 1L;
+        String nickname = "NewNickname";
+        Member member = new Member(null, nickname, "namu2024@gmail.com", "", "", List.of("ROLE_USER"));
+        MemberResponse response =  MemberResponse.from(member);
+
+        given(memberService.editMemberNickname(eq(projectId), eq(nickname), any()))
+                .willReturn(response);
+
+        // When & Then
+        mockMvc.perform(put("/v2/projects/members/nickname")
+                        .param("projectId", projectId.toString())
+                        .param("nickname", nickname))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("사용자 닉네임 수정 성공했습니다."))
+                .andExpect(jsonPath("$.data.nickname").value(nickname));
+    }
+
+    @Test
+    @DisplayName("상태메시지 설정 요청이 성공적으로 처리되어야 한다")
+    void editUserStateTest() throws Exception {
+        // Given
+        String state = "Working hard";
+
+        willDoNothing().given(memberService).editMemberState(eq(state), any(UserDetails.class));
+
+        // When & Then
+        mockMvc.perform(put("/v1/members/{state}", state))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("상태메시지 설정 성공"));
+    }
+
+    @Test
+    @DisplayName("프로젝트 보관설정/해제 V2 요청이 성공적으로 처리되어야 한다")
+    void storeProject2Test() throws Exception {
+        // Given
+        Long projectId = 1L;
+
+        given(memberService.storeProject2(eq(projectId), any()))
+                .willReturn(true);
+
+        // When & Then
+        mockMvc.perform(patch("/v2/members/storage/{projectId}", projectId)
+                        .with(oauth2Login()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("프로젝트 보관상태 변경"))
+                .andExpect(jsonPath("$.data").value(true));
+    }
+
+    @Test
+    @DisplayName("프로젝트 핀 설정/해제 요청이 성공적으로 처리되어야 한다")
+    void pinProjectTest() throws Exception {
+        // Given
+        Long projectId = 1L;
+
+        willDoNothing().given(projectService).pinProject(eq(projectId), any(UserDetails.class));
+
+        // When & Then
+        mockMvc.perform(patch("/v1/members/pin/{projectId}", projectId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("프로젝트 핀 상태 변경"));
+    }
+}

--- a/timepiece/src/test/java/com/appcenter/timepiece/controller/ProjectControllerTest.java
+++ b/timepiece/src/test/java/com/appcenter/timepiece/controller/ProjectControllerTest.java
@@ -1,0 +1,441 @@
+package com.appcenter.timepiece.controller;
+
+import com.appcenter.timepiece.common.dto.CommonPagingResponse;
+import com.appcenter.timepiece.config.TestSecurityConfig;
+import com.appcenter.timepiece.dto.member.MemberResponse;
+import com.appcenter.timepiece.dto.project.InvitationLinkResponse;
+import com.appcenter.timepiece.dto.project.InvitationResponse;
+import com.appcenter.timepiece.dto.project.PinProjectResponse;
+import com.appcenter.timepiece.dto.project.ProjectCreateUpdateRequest;
+import com.appcenter.timepiece.dto.project.ProjectResponse;
+import com.appcenter.timepiece.dto.project.ProjectThumbnailResponse;
+import com.appcenter.timepiece.dto.project.TransferPrivilegeRequest;
+import com.appcenter.timepiece.service.ProjectService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.*;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ProjectController.class)
+@Import(TestSecurityConfig.class)
+@WithMockUser
+public class ProjectControllerTest {
+
+    @MockBean
+    private ProjectService projectService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("프로젝트 상세 정보 조회가 성공적으로 처리되어야 한다")
+    void findProjectTest() throws Exception {
+        // Given
+        Long projectId = 1L;
+        ProjectResponse projectDetail = ProjectResponse.builder()
+                .projectId(1L)
+                .title("Test Project")
+                .description("Project Description")
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusDays(30))
+                .startTime(LocalTime.of(9, 0))
+                .endTime(LocalTime.of(18, 0))
+                .daysOfWeek(new HashSet<>(Arrays.asList(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.THURSDAY)))
+                .color("#FF0000")
+                .coverInfo(null)
+                .build();
+
+        when(projectService.findProject(eq(projectId), any(UserDetails.class)))
+                .thenReturn(projectDetail);
+
+        // When & Then
+        mockMvc.perform(get("/v1/projects/{projectId}", projectId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("프로젝트 조회 성공"))
+                .andExpect(jsonPath("$.data.projectId").value(projectId))
+                .andExpect(jsonPath("$.data.description").value("Project Description"))
+                .andExpect(jsonPath("$.data.startDate").exists())
+                .andExpect(jsonPath("$.data.endDate").exists())
+                .andExpect(jsonPath("$.data.startTime").exists())
+                .andExpect(jsonPath("$.data.daysOfWeek").exists())
+                .andExpect(jsonPath("$.data.color").hasJsonPath())
+                .andExpect(jsonPath("$.data.coverInfo").hasJsonPath());
+    }
+
+    @Test
+    @DisplayName("소속 프로젝트 전체 조회가 성공적으로 처리되어야 한다")
+    void findProjectsTest() throws Exception {
+        // Given
+        Long memberId = 1L;
+        ProjectThumbnailResponse projectThumbnail1 = ProjectThumbnailResponse.builder()
+                .projectId(1L)
+                .title("Test Project")
+                .description("Project Description")
+                .color("#FF0000")
+                .build();
+        ProjectThumbnailResponse projectThumbnail2 = ProjectThumbnailResponse.builder()
+                .projectId(2L)
+                .title("Test Project2")
+                .description("Project Description2")
+                .thumbnailUrl("http://example.com/thumbnail2")
+                .build();
+        List<ProjectThumbnailResponse> projects = Arrays.asList(projectThumbnail1, projectThumbnail2);
+
+        given(projectService.findProjects(eq(0), eq(6), eq(memberId), any(UserDetails.class)))
+                .willReturn((CommonPagingResponse) new CommonPagingResponse<>(0, 6, 2L, 1, projects));
+
+        // When & Then
+        mockMvc.perform(get("/v1/projects/members/{memberId}", memberId)
+                        .param("page", "0")
+                        .param("size", "6"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("프로젝트 목록 조회 성공"))
+                .andExpect(jsonPath("$.data.currentPage").value(0))
+                .andExpect(jsonPath("$.data.pageSize").value(6))
+                .andExpect(jsonPath("$.data.totalCount").value(2))
+                .andExpect(jsonPath("$.data.totalPages").value(1))
+                .andExpect(jsonPath("$.data.data[0].projectId").value(1))
+                .andExpect(jsonPath("$.data.data[0].title").value("Test Project"))
+                .andExpect(jsonPath("$.data.data[0].color").hasJsonPath())
+                .andExpect(jsonPath("$.data.data[0].thumbnailUrl").hasJsonPath());
+    }
+
+    @Test
+    @DisplayName("핀 설정된 프로젝트 조회가 성공적으로 처리되어야 한다")
+    void findPinProjectsTest() throws Exception {
+        // Given
+        Long memberId = 1L;
+        PinProjectResponse pinProject = PinProjectResponse.builder()
+                .projectId(1L)
+                .title("Pinned Project")
+                .description("Pinned Project Description")
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusDays(30))
+                .startTime(LocalTime.of(9, 0))
+                .endTime(LocalTime.of(18, 0))
+                .daysOfWeek(new HashSet<>(Arrays.asList(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.THURSDAY)))
+                .color("#FF0000")
+                .memberCount(1)
+                .schedule(Collections.emptyList())
+                .build();
+
+        when(projectService.findPinProjects(eq(memberId), any(UserDetails.class)))
+                .thenReturn(List.of(pinProject));
+
+        // When & Then
+        mockMvc.perform(get("/v1/projects/members/{memberId}/pin", memberId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("핀 설정된 프로젝트 조회 성공"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data[0].projectId").value(1))
+                .andExpect(jsonPath("$.data[0].title").value("Pinned Project"))
+                .andExpect(jsonPath("$.data[0].schedule").exists());
+    }
+
+    @Test
+    @DisplayName("프로젝트 검색이 성공적으로 처리되어야 한다")
+    void searchProjectsParamTest() throws Exception {
+        // Given
+        Long memberId = 1L;
+        String keyword = "test";
+        Boolean isStored = false;
+        ProjectThumbnailResponse projectThumbnail1 = ProjectThumbnailResponse.builder()
+                .projectId(1L)
+                .title("Test Project")
+                .description("Project Description")
+                .color("#FF0000")
+                .build();
+        ProjectThumbnailResponse projectThumbnail2 = ProjectThumbnailResponse.builder()
+                .projectId(2L)
+                .title("Test Project2")
+                .description("Project Description2")
+                .thumbnailUrl("http://example.com/thumbnail2")
+                .build();
+        List<ProjectThumbnailResponse> projects = Arrays.asList(projectThumbnail1, projectThumbnail2);
+
+        when(projectService.searchProjects(eq(0), eq(6), eq(isStored), eq(memberId), eq(keyword),
+                any(UserDetails.class)))
+                .thenReturn((CommonPagingResponse) new CommonPagingResponse<>(0, 6, 2L, 1, projects));
+
+        // When & Then
+        mockMvc.perform(get("/v2/projects/members/{memberId}", memberId)
+                        .param("page", "0")
+                        .param("size", "6")
+                        .param("keyword", keyword)
+                        .param("isStored", isStored.toString()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("프로젝트 검색 성공"))
+                .andExpect(jsonPath("$.data.currentPage").value(0))
+                .andExpect(jsonPath("$.data.pageSize").value(6))
+                .andExpect(jsonPath("$.data.totalCount").value(2))
+                .andExpect(jsonPath("$.data.totalPages").value(1))
+                .andExpect(jsonPath("$.data.data[0].projectId").value(1))
+                .andExpect(jsonPath("$.data.data[0].title").value("Test Project"))
+                .andExpect(jsonPath("$.data.data[0].description").value("Project Description"))
+                .andExpect(jsonPath("$.data.data[0].color").hasJsonPath())
+                .andExpect(jsonPath("$.data.data[0].thumbnailUrl").hasJsonPath());
+    }
+
+    @Test
+    @DisplayName("프로젝트에 속한 멤버 조회가 성공적으로 처리되어야 한다")
+    void findMembersInProjectTest() throws Exception {
+        // Given
+        Long projectId = 1L;
+        MemberResponse member1 = MemberResponse.builder()
+                .memberId(1L)
+                .email("test01@example.com")
+                .nickname("User1")
+                .state("ACTIVE")
+                .profileImageUrl("http://example.com/profile01")
+                .isPrivileged(true)
+                .build();
+        MemberResponse member2 = MemberResponse.builder()
+                .memberId(2L)
+                .email("test02@example.com")
+                .nickname("User2")
+                .state("ACTIVE")
+                .profileImageUrl("http://example.com/profile02")
+                .isPrivileged(false)
+                .build();
+        List<MemberResponse> members = List.of(member1, member2);
+
+        when(projectService.findMembers(eq(projectId), any(UserDetails.class)))
+                .thenReturn(members);
+
+        // When & Then
+        mockMvc.perform(get("/v1/projects/{projectId}/members", projectId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("프로젝트 내 사용자 조회 성공"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data[0].memberId").value(1))
+                .andExpect(jsonPath("$.data[0].nickname").value("User1"))
+                .andExpect(jsonPath("$.data[0].state").value("ACTIVE"))
+                .andExpect(jsonPath("$.data[0].profileImageUrl").value("http://example.com/profile01"))
+                .andExpect(jsonPath("$.data[0].isPrivileged").value(true));
+    }
+
+    @Test
+    @DisplayName("보관 프로젝트 목록 조회가 성공적으로 처리되어야 한다")
+    void findStoredProjectsTest() throws Exception {
+        // Given
+        ProjectThumbnailResponse projectThumbnail1 = ProjectThumbnailResponse.builder()
+                .projectId(1L)
+                .title("Test Project")
+                .description("Project Description")
+                .color("#FF0000")
+                .build();
+        ProjectThumbnailResponse projectThumbnail2 = ProjectThumbnailResponse.builder()
+                .projectId(2L)
+                .title("Test Project2")
+                .description("Project Description2")
+                .thumbnailUrl("http://example.com/thumbnail2")
+                .build();
+        List<ProjectThumbnailResponse> projects = Arrays.asList(projectThumbnail1, projectThumbnail2);
+
+        // Use raw type with unchecked cast to bypass generic type checking
+        when(projectService.findStoredProjects(eq(0), eq(6), any(UserDetails.class)))
+                .thenReturn((CommonPagingResponse) new CommonPagingResponse<>(0, 6, 2L, 1, projects));
+
+        // When & Then
+        mockMvc.perform(get("/v1/projects/stored")
+                        .param("page", "0")
+                        .param("size", "6"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("보관 프로젝트 목록 조회 성공"))
+                .andExpect(jsonPath("$.data.currentPage").value(0))
+                .andExpect(jsonPath("$.data.pageSize").value(6))
+                .andExpect(jsonPath("$.data.totalCount").value(2))
+                .andExpect(jsonPath("$.data.totalPages").value(1))
+                .andExpect(jsonPath("$.data.data[0].projectId").value(1))
+                .andExpect(jsonPath("$.data.data[0].title").value("Test Project"))
+                .andExpect(jsonPath("$.data.data[0].description").value("Project Description"))
+                .andExpect(jsonPath("$.data.data[0].color").hasJsonPath())
+                .andExpect(jsonPath("$.data.data[0].thumbnailUrl").hasJsonPath());
+    }
+
+    @Test
+    @DisplayName("프로젝트 생성이 성공적으로 처리되어야 한다")
+    void createProjectTest() throws Exception {
+        // Given
+        ProjectCreateUpdateRequest request = ProjectCreateUpdateRequest.builder()
+                .title("New Project")
+                .description("New Project Description")
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusDays(30))
+                .startTime(LocalTime.of(9, 0))
+                .endTime(LocalTime.of(18, 0))
+                .daysOfWeek(new HashSet<>(Arrays.asList(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.THURSDAY)))
+                .color("#FF0000")
+                .coverImageId("")
+                .build();
+
+        doNothing().when(projectService).createProject(any(ProjectCreateUpdateRequest.class), any(UserDetails.class));
+
+        // When & Then
+        mockMvc.perform(post("/v1/projects")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("프로젝트 생성 성공"));
+    }
+
+    @Test
+    @DisplayName("프로젝트 삭제가 성공적으로 처리되어야 한다")
+    void kickProjectTest() throws Exception {
+        // Given
+        Long projectId = 1L;
+
+        doNothing().when(projectService).deleteProject(eq(projectId), any(UserDetails.class));
+
+        // When & Then
+        mockMvc.perform(delete("/v1/projects/{projectId}", projectId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("프로젝트 삭제 성공"));
+    }
+
+    @Test
+    @DisplayName("회원 초대 링크 생성이 성공적으로 처리되어야 한다")
+    void generateInviteLinkTest() throws Exception {
+        // Given
+        Long projectId = 1L;
+        String title = "Test Project";
+        String url = "http://example.com/invite/abc123";
+        InvitationLinkResponse response = InvitationLinkResponse.builder()
+                .projectId(projectId)
+                .title(title)
+                .link(url)
+                .build();
+
+        when(projectService.generateInviteLink(eq(projectId), any(UserDetails.class)))
+                .thenReturn(response);
+
+        // When & Then
+        mockMvc.perform(post("/v1/projects/{projectId}/invitation", projectId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("초대링크를 성공적으로 생성했습니다"))
+                .andExpect(jsonPath("$.data.link").value(url));
+    }
+
+    @Test
+    @DisplayName("초대 링크 메타데이터 조회가 성공적으로 처리되어야 한다")
+    void decodeInviteLinkTest() throws Exception {
+        // Given
+        String url = "abc123";
+        String title = "Test Project";
+        String invitator = "User1";
+        InvitationResponse response = InvitationResponse.builder()
+                .title(title)
+                .invitator(invitator)
+                .isExpired(false)
+                .build();
+
+        when(projectService.decodeInviteLink(eq(url)))
+                .thenReturn(response);
+
+        // When & Then
+        mockMvc.perform(get("/v1/projects/invitations")
+                        .param("url", url))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("초대링크 정보를 성공적으로 조회했습니다"))
+                .andExpect(jsonPath("$.data.title").value(title))
+                .andExpect(jsonPath("$.data.invitator").value(invitator));
+    }
+
+    @Test
+    @DisplayName("회원 강퇴가 성공적으로 처리되어야 한다")
+    void kickTest() throws Exception {
+        // Given
+        Long projectId = 1L;
+        Long memberId = 2L;
+
+        doNothing().when(projectService).kick(eq(projectId), eq(memberId), any(UserDetails.class));
+
+        // When & Then
+        mockMvc.perform(delete("/v1/projects/{projectId}/members/{memberId}", projectId, memberId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("추방되었습니다"));
+    }
+
+    @Test
+    @DisplayName("프로젝트 나가기가 성공적으로 처리되어야 한다")
+    void goOutTest() throws Exception {
+        // Given
+        Long projectId = 1L;
+
+        doNothing().when(projectService).goOut(eq(projectId), any(UserDetails.class));
+
+        // When & Then
+        mockMvc.perform(delete("/v1/projects/{projectId}/me", projectId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("프로젝트에서 나갔습니다"));
+    }
+
+    @Test
+    @DisplayName("관리자 권한 양도가 성공적으로 처리되어야 한다")
+    void transferPrivilegeTest() throws Exception {
+        // Given
+        Long projectId = 1L;
+        Long toMemberId = 2L;
+        TransferPrivilegeRequest request = new TransferPrivilegeRequest(toMemberId);
+
+        doNothing().when(projectService)
+                .transferPrivilege(eq(projectId), any(TransferPrivilegeRequest.class), any(UserDetails.class));
+
+        // When & Then
+        mockMvc.perform(patch("/v1/projects/{projectId}/transfer-privilege", projectId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("프로젝트 관리 권한을 양도하였습니다."));
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
close #156

## 📝작업 내용
Spring Boot 애플리케이션의 여러 Controller에 대한 단위 테스트 코드를 구현했습니다.

- AuthControllerTest: 토큰 재발급 기능 테스트
- ImageControllerTest: 이미지 업로드 및 조회 기능 테스트
- MemberControllerTest: 멤버 조회, 닉네임 수정, 상태메시지 설정, 프로젝트 관련 기능 테스트
- ProjectControllerTest: 프로젝트 CRUD 및 관련 기능(멤버 관리, 초대 링크 등) 테스트
- TestSecurityConfig: 테스트 환경에서 사용할 보안 설정 클래스

모든 컨트롤러 테스트에서 WebMvcTest와 MockBean을 활용하여 컨트롤러 계층만 독립적으로 테스트할 수 있도록 구현했습니다. 각 API 엔드포인트의 성공 및 실패 케이스를 검증하여 API 응답이 예상대로 반환되는지 확인합니다.

## 💬리뷰 요구사항(선택)
1. TestSecurityConfig 설정이 적절한지 검토 부탁드립니다.
2. 각 테스트 케이스에서 MockMvc를 사용한 API 호출 방식과 검증 방식이 적절한지 확인 부탁드립니다.
3. 누락된 테스트 케이스가 있는지 확인 부탁드립니다.